### PR TITLE
Changed defaultArg implementation and fixed Tone.Buffer init with AudioBuffer

### DIFF
--- a/Tone/core/Buffer.js
+++ b/Tone/core/Buffer.js
@@ -64,7 +64,7 @@ define(["Tone/core/Tone"], function(Tone){
 		this.onload = options.onload.bind(this, this);
 
 		if (options.url instanceof AudioBuffer){
-			this._buffer.set(options.url);
+			this.set(options.url);
 			this.onload(this);
 		} else if (typeof options.url === "string"){
 			this.url = options.url;

--- a/Tone/core/Tone.js
+++ b/Tone/core/Tone.js
@@ -489,13 +489,7 @@ define(function(){
 	///////////////////////////////////////////////////////////////////////////
 
 	/**
-	 *  if a the given is undefined, use the fallback. 
-	 *  if both given and fallback are objects, given
-	 *  will be augmented with whatever properties it's
-	 *  missing which are in fallback
-	 *
-	 *  warning: if object is self referential, it will go into an an 
-	 *  infinite recursive loop. 
+	 *  Add default values for the properties that are not yet set
 	 *  
 	 *  @param  {*} given    
 	 *  @param  {*} fallback 
@@ -503,15 +497,15 @@ define(function(){
 	 */
 	Tone.prototype.defaultArg = function(given, fallback){
 		if (typeof given === "object" && typeof fallback === "object"){
-			var ret = {};
-			//make a deep copy of the given object
-			for (var givenProp in given) {
-				ret[givenProp] = this.defaultArg(given[givenProp], given[givenProp]);
-			}
 			for (var prop in fallback) {
-				ret[prop] = this.defaultArg(given[prop], fallback[prop]);
-			}
-			return ret;
+              	if (!given.hasOwnProperty(prop) ||
+                   	given[prop] === null ||
+                   	given[prop] === undefined) {
+                    given[prop] = fallback[prop];
+                }
+            }
+         
+            return given;
 		} else {
 			return isUndef(given) ? fallback : given;
 		}


### PR DESCRIPTION
I changed the defaultArg implementation, because it was causing issues with instanceof checks. Because the defaultArg created a copy of the given object, but stripping of any object type (like AudioBuffer) it would cause checks further down the line to fail. For instance in Tone.Buffer implementation there is a check if the given object is an AudioBuffer but this check would always fail because defaultArg would strip the AudioBuffer type of the object. I think the defaultArg implementation should do what it says, only set a value on a property of the given object if that property is not yet set (i.e. a default value). It is simple and should not break any other code in the project.

I also fixed a bug in Tone.Buffer where this._buffer.set is called where it should be this.set.