### PR TITLE
Close previous audio context

### DIFF
--- a/Tone/core/Tone.js
+++ b/Tone/core/Tone.js
@@ -765,6 +765,10 @@ define(function(){
 	 *  @param {AudioContext} ctx The new audio context to set
 	 */
 	Tone.setContext = function(ctx){
+		//First close the previouse audiocontext.
+		if(typeof Tone.context.close !== 'undefined'){
+			Tone.context.close();
+		}
 		//set the prototypes
 		Tone.prototype.context = ctx;
 		Tone.context = ctx;


### PR DESCRIPTION
Close previous audio context before assigning a new one:

api: https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/close

Ran into this issue when multiple embed codes of my application where used on 1 page.
Example usecase: http://stackoverflow.com/questions/25977269/using-audiocontext-in-multiple-iframes