### PR TITLE
Source.sync() design

### DIFF
--- a/Tone/core/Transport.js
+++ b/Tone/core/Transport.js
@@ -206,11 +206,10 @@ function(Tone){
 			tickTime += Tone.Time(this._swingTicks * 2/3, "i").eval() * amount;
 		} 
 		//do the loop test
-		if (this.loop){
-			if (ticks === this._loopEnd){
-				this.ticks = this._loopStart;
-				ticks = this._loopStart;
-				this.trigger("loop", tickTime);
+		if (this.loop) {
+			if (ticks === this._loopEnd) {
+				this.seek(this._loopStart)
+				this.trigger('loop', tickTime);
 			}
 		}
 		//process the single occurrence events
@@ -412,6 +411,28 @@ function(Tone){
 		this.trigger("pause", time);
 		return this;
 	};
+
+	/**
+	 *  Seek to a location on the transport timeline. 
+	 *  @param  {Time} [time=now]
+	 *  @returns {Tone.Transport} this
+	 */
+	Tone.Transport.prototype.seek = function (time) {
+
+		if (this.state=="started") {
+			this.trigger('stop',0)
+		}
+
+		this.ticks = this.toTicks(time)
+		this._ticks = this.toTicks(time)
+
+		if (this.state=="started") {
+			this.trigger('start',0)
+		}
+
+  };
+
+
 
 	///////////////////////////////////////////////////////////////////////////////
 	//	SETTERS/GETTERS

--- a/Tone/source/Source.js
+++ b/Tone/source/Source.js
@@ -62,10 +62,19 @@ function(Tone){
 		 *  @type {Function}
 		 *  @private
 		 */
-		this._syncStart = function(time, offset){
-			time = this.toSeconds(time);
-			time += this.toSeconds(this._startDelay);
-			this.start(time, offset);
+		this._syncStart = function(time){
+			
+			var delayFromNow = this.toSeconds(this._startDelay) - this.toSeconds(Tone.Transport.position)
+			var offset = 0
+
+			if (delayFromNow<0) {
+				offset = Math.abs(delayFromNow)
+				delayFromNow = 0
+			}
+
+			time += delayFromNow
+			this.start(time, offset)
+
 		}.bind(this);
 
 		/**


### PR DESCRIPTION
Changes design of Source.sync(), so that a synced player will play at a certain timeline position, rather than in relation to the transport’s start time.

API is still:

player.sync(“1m”)

Added Transport.seek() method and updated the looping mechanism to use .seek(). The .seek() method is created in order to start/stop synced players. This could also be done in Transport.position’s setter, but I ran into some stack overflows.

The loop timing is not perfect, to my ear; you may be able to find some improvements.

I didn’t run the build script yet; I will leave that to you if you incorporate these edits.