### PR TITLE
Call 'set' method instead of looking into Tone objects

### DIFF
--- a/Tone/core/Tone.js
+++ b/Tone/core/Tone.js
@@ -160,6 +160,8 @@ define(function(){
 			tmpObj[params] = value;
 			params = tmpObj;
 		}
+
+		paramLoop:
 		for (var attr in params){
 			value = params[attr];
 			var parent = this;
@@ -167,6 +169,12 @@ define(function(){
 				var attrSplit = attr.split(".");
 				for (var i = 0; i < attrSplit.length - 1; i++){
 					parent = parent[attrSplit[i]];
+					if (parent instanceof Tone) {
+						attrSplit.splice(0,i+1);
+						var innerParam = attrSplit.join(".");
+						parent.set(innerParam, value);
+						continue paramLoop;
+					}
 				}
 				attr = attrSplit[attrSplit.length - 1];
 			}


### PR DESCRIPTION
The `Tone.prototype.set` method, when passing arguments like ("synth.envelope.release", 10), will try to do `this.synth.envelope.release = 10`. This works great almost always, but not if something implements the `set` method.

For example, Tone.PolySynth does not have an `envelope` child, but you can do `polysynth.set("envelope.release", 10)` because its `set` method knows that you want to modify the unerlying voices, and not the PolySynth itself.

This pull request makes the `Tone.prototype.set` method use the `set` method if the object you try to modify is an instance of `Tone` instead of trying to modify the object directly.

For example, if you call `this.set("synth.envelope.release", 10)` and `this.synth` is a PolySynth it will call `this.synth.set("envelope.release", 10)`, so everything will work correctly.
