### PR TITLE
Point links to Synth Secrets on archive.org

### DIFF
--- a/Tone/effect/Freeverb.js
+++ b/Tone/effect/Freeverb.js
@@ -1,5 +1,5 @@
-define(["Tone/core/Tone", "Tone/component/LowpassCombFilter", "Tone/effect/StereoEffect", 
-	"Tone/signal/Signal", "Tone/component/Split", "Tone/component/Merge", "Tone/signal/ScaleExp"], 
+define(["Tone/core/Tone", "Tone/component/LowpassCombFilter", "Tone/effect/StereoEffect",
+	"Tone/signal/Signal", "Tone/component/Split", "Tone/component/Merge", "Tone/signal/ScaleExp"],
 function(Tone){
 
 	"use strict";
@@ -22,13 +22,13 @@ function(Tone){
 
 	/**
 	 *  @class Tone.Freeverb is a reverb based on [Freeverb](https://ccrma.stanford.edu/~jos/pasp/Freeverb.html).
-	 *         Read more on reverb on [SoundOnSound](http://www.soundonsound.com/sos/may00/articles/reverb.htm).
+	 *         Read more on reverb on [Sound On Sound](https://web.archive.org/web/20160404083902/http://www.soundonsound.com:80/sos/feb01/articles/synthsecrets.asp).
 	 *
 	 *  @extends {Tone.Effect}
 	 *  @constructor
-	 *  @param {NormalRange|Object} [roomSize] Correlated to the decay time. 
-	 *  @param {Frequency} [dampening] The cutoff frequency of a lowpass filter as part 
-	 *                                 of the reverb. 
+	 *  @param {NormalRange|Object} [roomSize] Correlated to the decay time.
+	 *  @param {Frequency} [dampening] The cutoff frequency of a lowpass filter as part
+	 *                                 of the reverb.
 	 *  @example
 	 * var freeverb = new Tone.Freeverb().toMaster();
 	 * freeverb.dampening.value = 1000;
@@ -42,14 +42,14 @@ function(Tone){
 
 		/**
 		 *  The roomSize value between. A larger roomSize
-		 *  will result in a longer decay. 
+		 *  will result in a longer decay.
 		 *  @type {NormalRange}
 		 *  @signal
 		 */
 		this.roomSize = new Tone.Signal(options.roomSize, Tone.Type.NormalRange);
 
 		/**
-		 *  The amount of dampening of the reverberant signal. 
+		 *  The amount of dampening of the reverberant signal.
 		 *  @type {Frequency}
 		 *  @signal
 		 */
@@ -120,12 +120,12 @@ function(Tone){
 	 *  @type {Object}
 	 */
 	Tone.Freeverb.defaults = {
-		"roomSize" : 0.7, 
+		"roomSize" : 0.7,
 		"dampening" : 3000
 	};
 
 	/**
-	 *  Clean up. 
+	 *  Clean up.
 	 *  @returns {Tone.Freeverb} this
 	 */
 	Tone.Freeverb.prototype.dispose = function(){

--- a/Tone/instrument/AMSynth.js
+++ b/Tone/instrument/AMSynth.js
@@ -1,5 +1,5 @@
-define(["Tone/core/Tone", "Tone/instrument/Synth", "Tone/signal/Signal", "Tone/signal/Multiply", 
-	"Tone/instrument/Monophonic", "Tone/signal/AudioToGain", "Tone/core/Gain"], 
+define(["Tone/core/Tone", "Tone/instrument/Synth", "Tone/signal/Signal", "Tone/signal/Multiply",
+	"Tone/instrument/Monophonic", "Tone/signal/AudioToGain", "Tone/core/Gain"],
 function(Tone){
 
 	"use strict";
@@ -8,13 +8,13 @@ function(Tone){
 	 *  @class  AMSynth uses the output of one Tone.Synth to modulate the
 	 *          amplitude of another Tone.Synth. The harmonicity (the ratio between
 	 *          the two signals) affects the timbre of the output signal greatly.
-	 *          Read more about Amplitude Modulation Synthesis on 
-	 *          [SoundOnSound](http://www.soundonsound.com/sos/mar00/articles/synthsecrets.htm).
+	 *          Read more about Amplitude Modulation Synthesis on
+	 *          [SoundOnSound](https://web.archive.org/web/20160404103653/http://www.soundonsound.com:80/sos/mar00/articles/synthsecrets.htm).
 	 *          <img src="https://docs.google.com/drawings/d/1TQu8Ed4iFr1YTLKpB3U1_hur-UwBrh5gdBXc8BxfGKw/pub?w=1009&h=457">
 	 *
 	 *  @constructor
 	 *  @extends {Tone.Monophonic}
-	 *  @param {Object} [options] the options available for the synth 
+	 *  @param {Object} [options] the options available for the synth
 	 *                            see defaults below
 	 *  @example
 	 * var synth = new Tone.AMSynth().toMaster();
@@ -26,7 +26,7 @@ function(Tone){
 		Tone.Monophonic.call(this, options);
 
 		/**
-		 *  The carrier voice. 
+		 *  The carrier voice.
 		 *  @type {Tone.Synth}
 		 *  @private
 		 */
@@ -46,7 +46,7 @@ function(Tone){
 		this.envelope = this._carrier.envelope.set(options.envelope);
 
 		/**
-		 *  The modulator voice. 
+		 *  The modulator voice.
 		 *  @type {Tone.Synth}
 		 *  @private
 		 */
@@ -82,7 +82,7 @@ function(Tone){
 
 		/**
 		 *  Harmonicity is the ratio between the two voices. A harmonicity of
-		 *  1 is no change. Harmonicity = 2 means a change of an octave. 
+		 *  1 is no change. Harmonicity = 2 means a change of an octave.
 		 *  @type {Positive}
 		 *  @signal
 		 *  @example
@@ -146,7 +146,7 @@ function(Tone){
 
 	/**
 	 *  trigger the attack portion of the note
-	 *  
+	 *
 	 *  @param  {Time} [time=now] the time the note will occur
 	 *  @param {NormalRange} [velocity=1] the velocity of the note
 	 *  @private
@@ -163,7 +163,7 @@ function(Tone){
 
 	/**
 	 *  trigger the release portion of the note
-	 *  
+	 *
 	 *  @param  {Time} [time=now] the time the note will release
 	 *  @private
 	 *  @returns {Tone.AMSynth} this

--- a/Tone/instrument/FMSynth.js
+++ b/Tone/instrument/FMSynth.js
@@ -1,4 +1,4 @@
-define(["Tone/core/Tone", "Tone/instrument/Synth", "Tone/signal/Signal", "Tone/signal/Multiply", "Tone/instrument/Monophonic"], 
+define(["Tone/core/Tone", "Tone/instrument/Synth", "Tone/signal/Signal", "Tone/signal/Multiply", "Tone/instrument/Monophonic"],
 function(Tone){
 
 	"use strict";
@@ -7,12 +7,12 @@ function(Tone){
 	 *  @class  FMSynth is composed of two Tone.Synths where one Tone.Synth modulates
 	 *          the frequency of a second Tone.Synth. A lot of spectral content 
 	 *          can be explored using the modulationIndex parameter. Read more about
-	 *          frequency modulation synthesis on [SoundOnSound](http://www.soundonsound.com/sos/apr00/articles/synthsecrets.htm).
+	 *          frequency modulation synthesis on Sound On Sound: [Part 1](https://web.archive.org/web/20160403123704/http://www.soundonsound.com/sos/apr00/articles/synthsecrets.htm), [Part 2](https://web.archive.org/web/20160403115835/http://www.soundonsound.com/sos/may00/articles/synth.htm).
 	 *          <img src="https://docs.google.com/drawings/d/1h0PUDZXPgi4Ikx6bVT6oncrYPLluFKy7lj53puxj-DM/pub?w=902&h=462">
 	 *
 	 *  @constructor
 	 *  @extends {Tone.Monophonic}
-	 *  @param {Object} [options] the options available for the synth 
+	 *  @param {Object} [options] the options available for the synth
 	 *                          see defaults below
 	 *  @example
 	 * var fmSynth = new Tone.FMSynth().toMaster();
@@ -82,7 +82,7 @@ function(Tone){
 
 		/**
 		 *  Harmonicity is the ratio between the two voices. A harmonicity of
-		 *  1 is no change. Harmonicity = 2 means a change of an octave. 
+		 *  1 is no change. Harmonicity = 2 means a change of an octave.
 		 *  @type {Positive}
 		 *  @signal
 		 *  @example
@@ -93,9 +93,9 @@ function(Tone){
 		this.harmonicity.units = Tone.Type.Positive;
 
 		/**
-		 *  The modulation index which essentially the depth or amount of the modulation. It is the 
-		 *  ratio of the frequency of the modulating signal (mf) to the amplitude of the 
-		 *  modulating signal (ma) -- as in ma/mf. 
+		 *  The modulation index which essentially the depth or amount of the modulation. It is the
+		 *  ratio of the frequency of the modulating signal (mf) to the amplitude of the
+		 *  modulating signal (ma) -- as in ma/mf.
 		 *	@type {Positive}
 		 *	@signal
 		 */
@@ -152,7 +152,7 @@ function(Tone){
 
 	/**
 	 * 	trigger the attack portion of the note
-	 *  
+	 *
 	 *  @param  {Time} [time=now] the time the note will occur
 	 *  @param {number} [velocity=1] the velocity of the note
 	 *  @returns {Tone.FMSynth} this
@@ -168,7 +168,7 @@ function(Tone){
 
 	/**
 	 *  trigger the release portion of the note
-	 *  
+	 *
 	 *  @param  {Time} [time=now] the time the note will release
 	 *  @returns {Tone.FMSynth} this
 	 *  @private

--- a/Tone/instrument/MetalSynth.js
+++ b/Tone/instrument/MetalSynth.js
@@ -1,5 +1,5 @@
-define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillator", "Tone/component/Filter",
-	"Tone/component/FrequencyEnvelope", "Tone/component/AmplitudeEnvelope", "Tone/core/Gain", "Tone/signal/Scale", "Tone/signal/Multiply"],
+define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillator", "Tone/component/Filter", 
+	"Tone/component/FrequencyEnvelope", "Tone/component/AmplitudeEnvelope", "Tone/core/Gain", "Tone/signal/Scale", "Tone/signal/Multiply"], 
 	function (Tone) {
 
 	/**
@@ -15,7 +15,7 @@ define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillato
 	 *  @class  A highly inharmonic and spectrally complex source with a highpass filter
 	 *          and amplitude envelope which is good for making metalophone sounds. Based
 	 *          on CymbalSynth by [@polyrhythmatic](https://github.com/polyrhythmatic).
-	 *          Inspiration from [Sound on Sound](https://web.archive.org/web/20160610143924/https://www.soundonsound.com/sos/jul02/articles/synthsecrets0702.asp).
+	 *          Inspiration from [Sound on Sound](http://www.soundonsound.com/sos/jul02/articles/synthsecrets0702.asp).
 	 *
 	 *  @constructor
 	 *  @extends {Tone.Instrument}
@@ -24,7 +24,7 @@ define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillato
 	 */
 	Tone.MetalSynth = function(options){
 
-		options = this.defaultArg(options, Tone.MetalSynth.defaults);
+		options = Tone.defaultArg(options, Tone.MetalSynth.defaults);
 		Tone.Instrument.call(this, options);
 
 		/**
@@ -82,7 +82,7 @@ define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillato
 		this._filterFreqScaler = new Tone.Scale(options.resonance, 7000);
 
 		/**
-		 *  The envelope which is connected both to the
+		 *  The envelope which is connected both to the 
 		 *  amplitude and highpass filter's cutoff frequency
 		 *  @type  {Tone.Envelope}
 		 */
@@ -139,12 +139,12 @@ define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillato
 	/**
 	 *  Trigger the attack.
 	 *  @param  {Time}  time      When the attack should be triggered.
-	 *  @param  {NormalRange=1}  velocity  The velocity that the envelope should be triggered at.
+	 *  @param  {NormalRange}  [velocity=1]  The velocity that the envelope should be triggered at.
 	 *  @return  {Tone.MetalSynth}  this
 	 */
 	Tone.MetalSynth.prototype.triggerAttack = function(time, vel) {
 		time = this.toSeconds(time);
-		vel = this.defaultArg(vel, 1);
+		vel = Tone.defaultArg(vel, 1);
 		this.envelope.triggerAttack(time, vel);
 		return this;
 	};
@@ -161,11 +161,11 @@ define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillato
 	};
 
 	/**
-	 *  Trigger the attack and release of the envelope after the given
-	 *  duration.
+	 *  Trigger the attack and release of the envelope after the given 
+	 *  duration. 
 	 *  @param  {Time}  duration  The duration before triggering the release
 	 *  @param  {Time}  time      When the attack should be triggered.
-	 *  @param  {NormalRange=1}  velocity  The velocity that the envelope should be triggered at.
+	 *  @param  {NormalRange}  [velocity=1]  The velocity that the envelope should be triggered at.
 	 *  @return  {Tone.MetalSynth}  this
 	 */
 	Tone.MetalSynth.prototype.triggerAttackRelease = function(duration, time, velocity) {

--- a/Tone/instrument/MetalSynth.js
+++ b/Tone/instrument/MetalSynth.js
@@ -1,5 +1,5 @@
-define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillator", "Tone/component/Filter", 
-	"Tone/component/FrequencyEnvelope", "Tone/component/AmplitudeEnvelope", "Tone/core/Gain", "Tone/signal/Scale", "Tone/signal/Multiply"], 
+define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillator", "Tone/component/Filter",
+	"Tone/component/FrequencyEnvelope", "Tone/component/AmplitudeEnvelope", "Tone/core/Gain", "Tone/signal/Scale", "Tone/signal/Multiply"],
 	function (Tone) {
 
 	/**
@@ -15,7 +15,7 @@ define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillato
 	 *  @class  A highly inharmonic and spectrally complex source with a highpass filter
 	 *          and amplitude envelope which is good for making metalophone sounds. Based
 	 *          on CymbalSynth by [@polyrhythmatic](https://github.com/polyrhythmatic).
-	 *          Inspiration from [Sound on Sound](http://www.soundonsound.com/sos/jul02/articles/synthsecrets0702.asp).
+	 *          Inspiration from [Sound on Sound](https://web.archive.org/web/20160610143924/https://www.soundonsound.com/sos/jul02/articles/synthsecrets0702.asp).
 	 *
 	 *  @constructor
 	 *  @extends {Tone.Instrument}
@@ -24,7 +24,7 @@ define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillato
 	 */
 	Tone.MetalSynth = function(options){
 
-		options = Tone.defaultArg(options, Tone.MetalSynth.defaults);
+		options = this.defaultArg(options, Tone.MetalSynth.defaults);
 		Tone.Instrument.call(this, options);
 
 		/**
@@ -82,7 +82,7 @@ define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillato
 		this._filterFreqScaler = new Tone.Scale(options.resonance, 7000);
 
 		/**
-		 *  The envelope which is connected both to the 
+		 *  The envelope which is connected both to the
 		 *  amplitude and highpass filter's cutoff frequency
 		 *  @type  {Tone.Envelope}
 		 */
@@ -139,12 +139,12 @@ define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillato
 	/**
 	 *  Trigger the attack.
 	 *  @param  {Time}  time      When the attack should be triggered.
-	 *  @param  {NormalRange}  [velocity=1]  The velocity that the envelope should be triggered at.
+	 *  @param  {NormalRange=1}  velocity  The velocity that the envelope should be triggered at.
 	 *  @return  {Tone.MetalSynth}  this
 	 */
 	Tone.MetalSynth.prototype.triggerAttack = function(time, vel) {
 		time = this.toSeconds(time);
-		vel = Tone.defaultArg(vel, 1);
+		vel = this.defaultArg(vel, 1);
 		this.envelope.triggerAttack(time, vel);
 		return this;
 	};
@@ -161,11 +161,11 @@ define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillato
 	};
 
 	/**
-	 *  Trigger the attack and release of the envelope after the given 
-	 *  duration. 
+	 *  Trigger the attack and release of the envelope after the given
+	 *  duration.
 	 *  @param  {Time}  duration  The duration before triggering the release
 	 *  @param  {Time}  time      When the attack should be triggered.
-	 *  @param  {NormalRange}  [velocity=1]  The velocity that the envelope should be triggered at.
+	 *  @param  {NormalRange=1}  velocity  The velocity that the envelope should be triggered at.
 	 *  @return  {Tone.MetalSynth}  this
 	 */
 	Tone.MetalSynth.prototype.triggerAttackRelease = function(duration, time, velocity) {

--- a/Tone/instrument/MetalSynth.js
+++ b/Tone/instrument/MetalSynth.js
@@ -1,5 +1,5 @@
-define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillator", "Tone/component/Filter", 
-	"Tone/component/FrequencyEnvelope", "Tone/component/AmplitudeEnvelope", "Tone/core/Gain", "Tone/signal/Scale", "Tone/signal/Multiply"], 
+define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillator", "Tone/component/Filter",
+	"Tone/component/FrequencyEnvelope", "Tone/component/AmplitudeEnvelope", "Tone/core/Gain", "Tone/signal/Scale", "Tone/signal/Multiply"],
 	function (Tone) {
 
 	/**
@@ -15,7 +15,7 @@ define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillato
 	 *  @class  A highly inharmonic and spectrally complex source with a highpass filter
 	 *          and amplitude envelope which is good for making metalophone sounds. Based
 	 *          on CymbalSynth by [@polyrhythmatic](https://github.com/polyrhythmatic).
-	 *          Inspiration from [Sound on Sound](http://www.soundonsound.com/sos/jul02/articles/synthsecrets0702.asp).
+	 *          Inspiration from [Sound on Sound](https://web.archive.org/web/20160610143924/https://www.soundonsound.com/sos/jul02/articles/synthsecrets0702.asp).
 	 *
 	 *  @constructor
 	 *  @extends {Tone.Instrument}
@@ -82,7 +82,7 @@ define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillato
 		this._filterFreqScaler = new Tone.Scale(options.resonance, 7000);
 
 		/**
-		 *  The envelope which is connected both to the 
+		 *  The envelope which is connected both to the
 		 *  amplitude and highpass filter's cutoff frequency
 		 *  @type  {Tone.Envelope}
 		 */
@@ -161,8 +161,8 @@ define(["Tone/core/Tone", "Tone/instrument/Instrument", "Tone/source/FMOscillato
 	};
 
 	/**
-	 *  Trigger the attack and release of the envelope after the given 
-	 *  duration. 
+	 *  Trigger the attack and release of the envelope after the given
+	 *  duration.
 	 *  @param  {Time}  duration  The duration before triggering the release
 	 *  @param  {Time}  time      When the attack should be triggered.
 	 *  @param  {NormalRange}  [velocity=1]  The velocity that the envelope should be triggered at.


### PR DESCRIPTION
Changes to docs, since Sound On Sound removed a lot of Synth Secrets articles and the links were dead. Links now point at the relevant articles on Archive.org

And Atom removed a fair bit of whitespace at the same time.