### PR TITLE
Round `Time#toTicks`

### DIFF
--- a/Tone/type/Time.js
+++ b/Tone/type/Time.js
@@ -232,7 +232,7 @@ define(["Tone/core/Tone", "Tone/type/TimeBase"], function (Tone) {
 	Tone.Time.prototype.toTicks = function(){
 		var quarterTime = this._beatsToUnits(1);
 		var quarters = this.valueOf() / quarterTime;
-		return Math.floor(quarters * Tone.Transport.PPQ);
+		return Math.round(quarters * Tone.Transport.PPQ);
 	};
 
 	/**

--- a/test/type/Time.js
+++ b/test/type/Time.js
@@ -181,11 +181,11 @@ define(["helper/Basic", "Test", "Tone/type/Time", "Tone/core/Tone", "helper/Offl
 			it ("converts time into ticks", function(){
 				return Offline(function(Transport){
 					expect(Time("2n").toTicks()).to.equal(2 * Transport.PPQ);
-          // floating point checks
-          var bpmOrig = Tone.Transport.bpm.value;
-          Tone.Transport.bpm.value = 100;
-          expect(Time('0:1:3').toTicks()).to.equal(1.75 * Transport.PPQ)
-          Tone.Transport.bpm.value = bpmOrig;
+					// floating point checks
+					var bpmOrig = Tone.Transport.bpm.value;
+					Tone.Transport.bpm.value = 100;
+					expect(Time('0:1:3').toTicks()).to.equal(1.75 * Transport.PPQ)
+					Tone.Transport.bpm.value = bpmOrig;
 				});
 			});
 

--- a/test/type/Time.js
+++ b/test/type/Time.js
@@ -181,6 +181,11 @@ define(["helper/Basic", "Test", "Tone/type/Time", "Tone/core/Tone", "helper/Offl
 			it ("converts time into ticks", function(){
 				return Offline(function(Transport){
 					expect(Time("2n").toTicks()).to.equal(2 * Transport.PPQ);
+          // floating point checks
+          var bpmOrig = Tone.Transport.bpm.value;
+          Tone.Transport.bpm.value = 100;
+          expect(Time('0:1:3').toTicks()).to.equal(1.75 * Transport.PPQ)
+          Tone.Transport.bpm.value = bpmOrig;
 				});
 			});
 


### PR DESCRIPTION
The first commit in this PR demonstrates the issue, and the second is a proposed fix.

I'm not sure if there's a better more broadly applicable fix that may prevent other floating point issues, but this appears to do the trick.

fixes #255 

