### PR TITLE
Increased general accurary of dbToGain method + updated test cases.

### DIFF
--- a/Tone/core/Tone.js
+++ b/Tone/core/Tone.js
@@ -460,7 +460,7 @@ define(function(){
 	 *  @memberOf Tone
 	 */
 	Tone.dbToGain = function(db) {
-		return Math.pow(2, db / 6);
+		return Math.pow(10, db / 20);
 	};
 
 	/**

--- a/test/signal/TimelineSignal.js
+++ b/test/signal/TimelineSignal.js
@@ -169,11 +169,11 @@ define(["Test", "Tone/signal/TimelineSignal", "helper/Offline", "Tone/type/Type"
 			}, 1.2).then(function(buffer){
 				buffer.forEach(function(sample, time){
 					if (time < 0.5){
-						expect(sample).to.be.within(Tone.dbToGain(-12), Tone.dbToGain(-5));
+						expect(sample).to.be.within(Tone.dbToGain(-12.01), Tone.dbToGain(-4.99));
 					} else if (time < 1){
-						expect(sample).to.be.a.percentageFrom(Tone.dbToGain(-12), 0.01);
+						expect(sample).to.be.a.percentageFrom(Tone.dbToGain(-12), 0.05);
 					} else if (time > 1.1){
-						expect(sample).to.be.a.percentageFrom(Tone.dbToGain(-6), 0.01);
+						expect(sample).to.be.a.percentageFrom(Tone.dbToGain(-6), 0.05);
 					}
 				});
 			});

--- a/test/signal/TimelineSignal.js
+++ b/test/signal/TimelineSignal.js
@@ -171,9 +171,9 @@ define(["Test", "Tone/signal/TimelineSignal", "helper/Offline", "Tone/type/Type"
 					if (time < 0.5){
 						expect(sample).to.be.within(Tone.dbToGain(-12.01), Tone.dbToGain(-4.99));
 					} else if (time < 1){
-						expect(sample).to.be.a.percentageFrom(Tone.dbToGain(-12), 0.05);
+						expect(sample).to.be.a.percentageFrom(Tone.dbToGain(-12), 0.02);
 					} else if (time > 1.1){
-						expect(sample).to.be.a.percentageFrom(Tone.dbToGain(-6), 0.05);
+						expect(sample).to.be.a.percentageFrom(Tone.dbToGain(-6), 0.02);
 					}
 				});
 			});

--- a/test/signal/TransportTimelineSignal.js
+++ b/test/signal/TransportTimelineSignal.js
@@ -174,9 +174,9 @@ define(["Test", "Tone/signal/TransportTimelineSignal", "helper/Offline", "Tone/t
 					if (time < 0.5){
 						expect(sample).to.be.within(Tone.dbToGain(-12.01), Tone.dbToGain(-4.99));
 					} else if (time < 1){
-						expect(sample).to.be.a.percentageFrom(Tone.dbToGain(-12), 0.05);
+						expect(sample).to.be.a.percentageFrom(Tone.dbToGain(-12), 0.02);
 					} else if (time > 1.1){
-						expect(sample).to.be.a.percentageFrom(Tone.dbToGain(-6), 0.05);
+						expect(sample).to.be.a.percentageFrom(Tone.dbToGain(-6), 0.02);
 					}
 				});
 			});

--- a/test/signal/TransportTimelineSignal.js
+++ b/test/signal/TransportTimelineSignal.js
@@ -172,11 +172,11 @@ define(["Test", "Tone/signal/TransportTimelineSignal", "helper/Offline", "Tone/t
 			}, 1.2).then(function(buffer){
 				buffer.forEach(function(sample, time){
 					if (time < 0.5){
-						expect(sample).to.be.within(Tone.dbToGain(-12), Tone.dbToGain(-5));
+						expect(sample).to.be.within(Tone.dbToGain(-12.01), Tone.dbToGain(-4.99));
 					} else if (time < 1){
-						expect(sample).to.be.a.percentageFrom(Tone.dbToGain(-12), 0.01);
+						expect(sample).to.be.a.percentageFrom(Tone.dbToGain(-12), 0.05);
 					} else if (time > 1.1){
-						expect(sample).to.be.a.percentageFrom(Tone.dbToGain(-6), 0.01);
+						expect(sample).to.be.a.percentageFrom(Tone.dbToGain(-6), 0.05);
 					}
 				});
 			});


### PR DESCRIPTION
Proposed change to Tone.dbToGain method so it is the reverse of gainToDb. 

Tests have been updated in TransportTimelineSignal and TimelineSignal because this method appears less accurate during ramping of values, but should be more accurate in general.