### PR TITLE
Fix AudioNode.disconnect error when disconnecting from signals/params

### DIFF
--- a/Tone/core/Context.js
+++ b/Tone/core/Context.js
@@ -538,7 +538,11 @@ define(["Tone/core/Tone", "Tone/core/Emitter", "Tone/core/Timeline", "Tone/shim/
 				this.disconnect(B.input, outNum, inNum);
 			} else {
 				try {
-					nativeDisconnect.apply(this, arguments);
+					if (B instanceof AudioParam){
+						nativeDisconnect.call(this, B, outNum);
+					} else {
+						nativeDisconnect.apply(this, arguments);
+					}
 				} catch (e){
 					throw new Error("error disconnecting node: "+B+"\n"+e);
 				}


### PR DESCRIPTION
WebAudio's AudioNode.disconnect will throw an error if specifying an input number when disconnecting from an AudioParam (at least in chrome and firefox for linux). This pull request checks if we're disconnecting from an AudioParam before calling WebAudio's native disconnect method, and calls it without specifying an input if we are.
