### PR TITLE
fix Tone.Midi.toFrequency example

### DIFF
--- a/Tone/type/Midi.js
+++ b/Tone/type/Midi.js
@@ -84,7 +84,7 @@ define(["Tone/core/Tone", "Tone/type/Frequency"], function(Tone){
 	 *  Return the value of the frequency as a MIDI note
 	 *  @return  {MIDI}
 	 *  @example
-	 * Tone.Midi(60).toMidi(); //60
+	 * Tone.Midi(60).toFrequency(); //261.6255653005986
 	 */
 	Tone.Midi.prototype.toFrequency = function(){
 		return Tone.Frequency.mtof(this.toMidi());


### PR DESCRIPTION
Hi there.

I noticed that the `Tone.Midi.toFrequency` example in the docs seems to be copypasta from `Tone.Midi.toMidi`.