### PR TITLE
fix Tone.Midi examples

### DIFF
--- a/Tone/type/Midi.js
+++ b/Tone/type/Midi.js
@@ -84,7 +84,7 @@ define(["Tone/core/Tone", "Tone/type/Frequency"], function(Tone){
 	 *  Return the value of the frequency as a MIDI note
 	 *  @return  {MIDI}
 	 *  @example
-	 * Tone.Midi(60).toMidi(); //60
+	 * Tone.Midi(60).toFrequency(); //261.6255653005986
 	 */
 	Tone.Midi.prototype.toFrequency = function(){
 		return Tone.Frequency.mtof(this.toMidi());
@@ -95,7 +95,7 @@ define(["Tone/core/Tone", "Tone/type/Frequency"], function(Tone){
 	 *  @param  {Interval}  interval
 	 *  @return  {Tone.Frequency} A new transposed frequency
 	 *  @example
-	 * Tone.Frequency("A4").transpose(3); //"C5"
+	 * Tone.Midi("A4").transpose(3); //"C5"
 	 */
 	Tone.Midi.prototype.transpose = function(interval){
 		return new this.constructor(this.toMidi() + interval);


### PR DESCRIPTION
Greetings.

I noticed some copypasta in the Tone.Midi docs. I'm really enjoying the library, so thought I'd clean them up. Thanks!


