### PR TITLE
Time miscalculation fix

### DIFF
--- a/Tone/type/Time.js
+++ b/Tone/type/Time.js
@@ -111,6 +111,7 @@ define(["Tone/core/Tone", "Tone/type/TimeBase", "Tone/type/Frequency"], function
 	Tone.Time.prototype.toBarsBeatsSixteenths = function(){
 		var quarterTime = this._beatsToUnits(1);
 		var quarters = this.valueOf() / quarterTime;
+		quarters = parseFloat(quarters.toFixed(4));
 		var measures = Math.floor(quarters / this._getTimeSignature());
 		var sixteenths = (quarters % 1) * 4;
 		quarters = Math.floor(quarters) % this._getTimeSignature();


### PR DESCRIPTION
Times being converted to BarsBeatsSixteenths have the potential to miscalculate due to an extended floating point number within the function.

Example of error:
https://jsfiddle.net/timboie/1vztuhz1/

Fix validation:
https://jsfiddle.net/timboie/6e7d31t3/

Any further testing is appreciated

1. Please make all pull requests on the `dev` branch.
2. Don't commit build files
2. Try to get all [tests](https://github.com/Tonejs/Tone.js/wiki/Testing) to pass.


