### PR TITLE
Remove subtle blip on waveform in analysis example

### DIFF
--- a/examples/analysis.html
+++ b/examples/analysis.html
@@ -97,7 +97,7 @@
 			waveContext.lineJoin = "round";
 			waveContext.lineWidth = 6;
 			waveContext.strokeStyle = waveformGradient;
-			waveContext.moveTo(0, (values[0] / 255) * canvasHeight);
+			waveContext.moveTo(0, (values[0] + 1) / 2 * canvasHeight);
 			for (var i = 1, len = values.length; i < len; i++){
 				var val = (values[i] + 1) / 2;
 				var x = canvasWidth * (i / len);


### PR DESCRIPTION
There's a subtle blip at the beginning of the waveform on the analysis example page due to a special case for the first point on the drawn line:

<img width="891" alt="screen shot 2018-12-11 at 10 10 17 pm" src="https://user-images.githubusercontent.com/1087646/49844761-33264a00-fd92-11e8-9a83-bafb85ca4b18.png">

This PR fixes that blip:

<img width="1180" alt="screen shot 2018-12-11 at 10 12 31 pm" src="https://user-images.githubusercontent.com/1087646/49844781-3e797580-fd92-11e8-9440-76312b5338f5.png">
