### PR TITLE
WIP: Replace patches

### DIFF
--- a/Tone/component/AmplitudeEnvelope.js
+++ b/Tone/component/AmplitudeEnvelope.js
@@ -40,7 +40,7 @@ define(["../core/Tone", "../component/Envelope", "../core/Gain"], function(Tone)
 		 */
 		this.input = this.output = new Tone.Gain();
 
-		this._sig.connect(this.output.gain);
+		Tone.connect(this._sig, this.output.gain);
 	};
 
 	Tone.extend(Tone.AmplitudeEnvelope, Tone.Envelope);

--- a/Tone/component/CrossFade.js
+++ b/Tone/component/CrossFade.js
@@ -82,10 +82,10 @@ define(["../core/Tone", "../signal/Signal", "../signal/Subtract",
 		//connections
 		this.a.connect(this.output);
 		this.b.connect(this.output);
-		this.fade.chain(this._equalPowerB, this.b.gain);
+		Tone.chain(this.fade, this._equalPowerB, this.b.gain);
 		this._one.connect(this._invert, 0, 0);
 		this.fade.connect(this._invert, 0, 1);
-		this._invert.chain(this._equalPowerA, this.a.gain);
+		Tone.chain(this._invert, this._equalPowerA, this.a.gain);
 		this._readOnly("fade");
 	};
 

--- a/Tone/component/CrossFade.js
+++ b/Tone/component/CrossFade.js
@@ -80,11 +80,11 @@ define(["../core/Tone", "../signal/Signal", "../signal/Subtract",
 		this._invert = new Tone.Subtract();
 
 		//connections
-		this.a.connect(this.output);
-		this.b.connect(this.output);
+		Tone.connect(this.a, this.output);
+		Tone.connect(this.b, this.output);
 		Tone.chain(this.fade, this._equalPowerB, this.b.gain);
-		this._one.connect(this._invert, 0, 0);
-		this.fade.connect(this._invert, 0, 1);
+		Tone.connect(this._one, this._invert, 0, 0);
+		Tone.connect(this.fade, this._invert, 0, 1);
 		Tone.chain(this._invert, this._equalPowerA, this.a.gain);
 		this._readOnly("fade");
 	};

--- a/Tone/component/EQ3.js
+++ b/Tone/component/EQ3.js
@@ -101,9 +101,9 @@ define(["../core/Tone", "../component/MultibandSplit", "../core/Gain", "../core/
 		this.highFrequency = this._multibandSplit.highFrequency;
 
 		//the frequency bands
-		this._multibandSplit.low.chain(this._lowGain, this.output);
-		this._multibandSplit.mid.chain(this._midGain, this.output);
-		this._multibandSplit.high.chain(this._highGain, this.output);
+		Tone.chain(this._multibandSplit.low, this._lowGain, this.output);
+		Tone.chain(this._multibandSplit.mid, this._midGain, this.output);
+		Tone.chain(this._multibandSplit.high, this._highGain, this.output);
 		this._readOnly(["low", "mid", "high", "lowFrequency", "highFrequency"]);
 	};
 

--- a/Tone/component/FeedbackCombFilter.js
+++ b/Tone/component/FeedbackCombFilter.js
@@ -45,7 +45,7 @@ define(["../core/Tone", "../signal/ScaleExp", "../signal/Signal",
 		 */
 		this.resonance = this._feedback.gain;
 
-		this._delay.chain(this._feedback, this._delay);
+		Tone.chain(this._delay, this._feedback, this._delay);
 		this._readOnly(["resonance", "delayTime"]);
 	};
 

--- a/Tone/component/Filter.js
+++ b/Tone/component/Filter.js
@@ -152,10 +152,10 @@ define(["../core/Tone", "../signal/Signal", "../core/AudioNode"], function(Tone)
 			for (var count = 0; count < cascadingCount; count++){
 				var filter = this.context.createBiquadFilter();
 				filter.type = this._type;
-				this.frequency.connect(filter.frequency);
-				this.detune.connect(filter.detune);
-				this.Q.connect(filter.Q);
-				this.gain.connect(filter.gain);
+				Tone.connect(this.frequency, filter.frequency);
+				Tone.connect(this.detune, filter.detune);
+				Tone.connect(this.Q, filter.Q);
+				Tone.connect(this.gain, filter.gain);
 				this._filters[count] = filter;
 			}
 			//connect them up

--- a/Tone/component/Follower.js
+++ b/Tone/component/Follower.js
@@ -56,8 +56,8 @@ define(["../core/Tone", "../signal/Abs", "../signal/Subtract",
 		 */
 		this._smoothing = options.smoothing;
 
-		this.input.connect(this._delay, this._sub);
-		this.input.connect(this._sub, 0, 1);
+		Tone.connect(this.input, this._delay, this._sub);
+		Tone.connect(this.input, this._sub, 0, 1);
 		Tone.chain(this._sub, this._abs, this._filter, this.output);
 
 		//set the smoothing initially

--- a/Tone/component/Follower.js
+++ b/Tone/component/Follower.js
@@ -58,7 +58,7 @@ define(["../core/Tone", "../signal/Abs", "../signal/Subtract",
 
 		this.input.connect(this._delay, this._sub);
 		this.input.connect(this._sub, 0, 1);
-		this._sub.chain(this._abs, this._filter, this.output);
+		Tone.chain(this._sub, this._abs, this._filter, this.output);
 
 		//set the smoothing initially
 		this.smoothing = options.smoothing;

--- a/Tone/component/Gate.js
+++ b/Tone/component/Gate.js
@@ -37,7 +37,7 @@ define(["../core/Tone", "../component/Follower", "../signal/GreaterThan", "../co
 		this._gt = new Tone.GreaterThan(Tone.dbToGain(options.threshold));
 
 		//the connections
-		this.input.connect(this.output);
+		Tone.connect(this.input, this.output);
 		//the control signal
 		Tone.chain(this.input, this._follower, this._gt, this.output.gain);
 	};

--- a/Tone/component/Gate.js
+++ b/Tone/component/Gate.js
@@ -39,7 +39,7 @@ define(["../core/Tone", "../component/Follower", "../signal/GreaterThan", "../co
 		//the connections
 		this.input.connect(this.output);
 		//the control signal
-		this.input.chain(this._follower, this._gt, this.output.gain);
+		Tone.chain(this.input, this._follower, this._gt, this.output.gain);
 	};
 
 	Tone.extend(Tone.Gate, Tone.AudioNode);

--- a/Tone/component/LFO.js
+++ b/Tone/component/LFO.js
@@ -95,7 +95,7 @@ define(["../core/Tone", "../source/Oscillator", "../signal/Scale", "../core/Audi
 		this.units = options.units;
 
 		//connect it up
-		this._oscillator.chain(this._a2g, this._scaler);
+		Tone.chain(this._oscillator, this._a2g, this._scaler);
 		this._zeros.connect(this._a2g);
 		this._stoppedSignal.connect(this._a2g);
 		this._readOnly(["amplitude", "frequency"]);

--- a/Tone/component/LFO.js
+++ b/Tone/component/LFO.js
@@ -96,8 +96,8 @@ define(["../core/Tone", "../source/Oscillator", "../signal/Scale", "../core/Audi
 
 		//connect it up
 		Tone.chain(this._oscillator, this._a2g, this._scaler);
-		this._zeros.connect(this._a2g);
-		this._stoppedSignal.connect(this._a2g);
+		Tone.connect(this._zeros, this._a2g);
+		Tone.connect(this._stoppedSignal, this._a2g);
 		this._readOnly(["amplitude", "frequency"]);
 		this.phase = options.phase;
 	};

--- a/Tone/component/LowpassCombFilter.js
+++ b/Tone/component/LowpassCombFilter.js
@@ -59,7 +59,7 @@ define(["../core/Tone", "../signal/Signal", "../component/Filter", "../core/Audi
 		this.resonance = this._combFilter.resonance;
 
 		//connections
-		this._lowpass.connect(this._combFilter);
+		Tone.connect(this._lowpass, this._combFilter);
 		this._readOnly(["dampening", "resonance", "delayTime"]);
 	};
 

--- a/Tone/component/Merge.js
+++ b/Tone/component/Merge.js
@@ -45,8 +45,8 @@ define(["../core/Tone", "../core/AudioNode"], function(Tone){
 		this._merger = this.output = this.context.createChannelMerger(2);
 
 		//connections
-		this.left.connect(this._merger, 0, 0);
-		this.right.connect(this._merger, 0, 1);
+		Tone.connect(this.left, this._merger, 0, 0);
+		Tone.connect(this.right, this._merger, 0, 1);
 
 		this.left.channelCount = 1;
 		this.right.channelCount = 1;

--- a/Tone/component/MidSideCompressor.js
+++ b/Tone/component/MidSideCompressor.js
@@ -43,8 +43,8 @@ define(["../core/Tone", "../component/MidSideSplit", "../component/MidSideMerge"
 		 */
 		this.side = new Tone.Compressor(options.side);
 
-		this._midSideSplit.mid.chain(this.mid, this._midSideMerge.mid);
-		this._midSideSplit.side.chain(this.side, this._midSideMerge.side);
+		Tone.chain(this._midSideSplit.mid, this.mid, this._midSideMerge.mid);
+		Tone.chain(this._midSideSplit.side, this.side, this._midSideMerge.side);
 		this._readOnly(["mid", "side"]);
 	};
 

--- a/Tone/component/MidSideMerge.js
+++ b/Tone/component/MidSideMerge.js
@@ -69,14 +69,14 @@ define(["../core/Tone", "../signal/Signal", "../signal/Subtract", "../signal/Add
 		 */
 		this._merge = this.output = new Tone.Merge();
 
-		this.mid.connect(this._left, 0, 0);
-		this.side.connect(this._left, 0, 1);
-		this.mid.connect(this._right, 0, 0);
-		this.side.connect(this._right, 0, 1);
-		this._left.connect(this._timesTwoLeft);
-		this._right.connect(this._timesTwoRight);
-		this._timesTwoLeft.connect(this._merge, 0, 0);
-		this._timesTwoRight.connect(this._merge, 0, 1);
+		Tone.connect(this.mid, this._left, 0, 0);
+		Tone.connect(this.side, this._left, 0, 1);
+		Tone.connect(this.mid, this._right, 0, 0);
+		Tone.connect(this.side, this._right, 0, 1);
+		Tone.connect(this._left, this._timesTwoLeft);
+		Tone.connect(this._right, this._timesTwoRight);
+		Tone.connect(this._timesTwoLeft, this._merge, 0, 0);
+		Tone.connect(this._timesTwoRight, this._merge, 0, 1);
 	};
 
 	Tone.extend(Tone.MidSideMerge, Tone.AudioNode);

--- a/Tone/component/MidSideSplit.js
+++ b/Tone/component/MidSideSplit.js
@@ -52,12 +52,12 @@ define(["../core/Tone", "../signal/Add", "../signal/Subtract", "../signal/Signal
 		 */
 		this.side = this.output[1] = new Tone.Multiply(Math.SQRT1_2);
 
-		this._split.connect(this._midAdd, 0, 0);
-		this._split.connect(this._midAdd, 1, 1);
-		this._split.connect(this._sideSubtract, 0, 0);
-		this._split.connect(this._sideSubtract, 1, 1);
-		this._midAdd.connect(this.mid);
-		this._sideSubtract.connect(this.side);
+		Tone.connect(this._split, this._midAdd, 0, 0);
+		Tone.connect(this._split, this._midAdd, 1, 1);
+		Tone.connect(this._split, this._sideSubtract, 0, 0);
+		Tone.connect(this._split, this._sideSubtract, 1, 1);
+		Tone.connect(this._midAdd, this.mid);
+		Tone.connect(this._sideSubtract, this.side);
 	};
 
 	Tone.extend(Tone.MidSideSplit, Tone.AudioNode);

--- a/Tone/component/Mono.js
+++ b/Tone/component/Mono.js
@@ -22,8 +22,8 @@ define(["../core/Tone", "../component/Merge", "../core/AudioNode"], function(Ton
 		 */
 		this._merge = this.output = new Tone.Merge();
 
-		this.input.connect(this._merge, 0, 0);
-		this.input.connect(this._merge, 0, 1);
+		Tone.connect(this.input, this._merge, 0, 0);
+		Tone.connect(this.input, this._merge, 0, 1);
 	};
 
 	Tone.extend(Tone.Mono, Tone.AudioNode);

--- a/Tone/component/MultibandCompressor.js
+++ b/Tone/component/MultibandCompressor.js
@@ -72,9 +72,9 @@ define(["../core/Tone", "../component/MultibandSplit", "../component/Compressor"
 		this.high = new Tone.Compressor(options.high);
 
 		//connect the compressor
-		this._splitter.low.chain(this.low, this.output);
-		this._splitter.mid.chain(this.mid, this.output);
-		this._splitter.high.chain(this.high, this.output);
+		Tone.chain(this._splitter.low, this.low, this.output);
+		Tone.chain(this._splitter.mid, this.mid, this.output);
+		Tone.chain(this._splitter.high, this.high, this.output);
 
 		this._readOnly(["high", "mid", "low", "highFrequency", "lowFrequency"]);
 	};

--- a/Tone/component/MultibandSplit.js
+++ b/Tone/component/MultibandSplit.js
@@ -79,15 +79,15 @@ define(["../core/Tone", "../component/Filter", "../signal/Signal", "../core/Gain
 		this.input.fan(this.low, this.high);
 		Tone.chain(this.input, this._lowMidFilter, this.mid);
 		//the frequency control signal
-		this.lowFrequency.connect(this.low.frequency);
-		this.lowFrequency.connect(this._lowMidFilter.frequency);
-		this.highFrequency.connect(this.mid.frequency);
-		this.highFrequency.connect(this.high.frequency);
+		Tone.connect(this.lowFrequency, this.low.frequency);
+		Tone.connect(this.lowFrequency, this._lowMidFilter.frequency);
+		Tone.connect(this.highFrequency, this.mid.frequency);
+		Tone.connect(this.highFrequency, this.high.frequency);
 		//the Q value
-		this.Q.connect(this.low.Q);
-		this.Q.connect(this._lowMidFilter.Q);
-		this.Q.connect(this.mid.Q);
-		this.Q.connect(this.high.Q);
+		Tone.connect(this.Q, this.low.Q);
+		Tone.connect(this.Q, this._lowMidFilter.Q);
+		Tone.connect(this.Q, this.mid.Q);
+		Tone.connect(this.Q, this.high.Q);
 
 		this._readOnly(["high", "mid", "low", "highFrequency", "lowFrequency"]);
 	};

--- a/Tone/component/MultibandSplit.js
+++ b/Tone/component/MultibandSplit.js
@@ -77,7 +77,7 @@ define(["../core/Tone", "../component/Filter", "../signal/Signal", "../core/Gain
 		this.Q = new Tone.Signal(options.Q);
 
 		this.input.fan(this.low, this.high);
-		this.input.chain(this._lowMidFilter, this.mid);
+		Tone.chain(this.input, this._lowMidFilter, this.mid);
 		//the frequency control signal
 		this.lowFrequency.connect(this.low.frequency);
 		this.lowFrequency.connect(this._lowMidFilter.frequency);

--- a/Tone/component/PanVol.js
+++ b/Tone/component/PanVol.js
@@ -47,7 +47,7 @@ define(["../core/Tone", "../component/Panner", "../component/Volume", "../core/A
 		this.volume = this._volume.volume;
 
 		//connections
-		this._panner.connect(this._volume);
+		Tone.connect(this._panner, this._volume);
 		this.mute = options.mute;
 
 		this._readOnly(["pan", "volume"]);

--- a/Tone/component/ScaledEnvelope.js
+++ b/Tone/component/ScaledEnvelope.js
@@ -43,7 +43,7 @@ define(["../core/Tone", "../component/Envelope", "../signal/Scale"], function(To
 		 */
 		this._scale = this.output = new Tone.Scale(options.min, options.max);
 
-		this._sig.chain(this._exp, this._scale);
+		Tone.chain(this._sig, this._exp, this._scale);
 	};
 
 	Tone.extend(Tone.ScaledEnvelope, Tone.Envelope);

--- a/Tone/component/Split.js
+++ b/Tone/component/Split.js
@@ -37,8 +37,8 @@ define(["../core/Tone", "../core/Gain", "../core/AudioNode"], function(Tone){
 		this.right = this.output[1] = new Tone.Gain();
 
 		//connections
-		this._splitter.connect(this.left, 0, 0);
-		this._splitter.connect(this.right, 1, 0);
+		Tone.connect(this._splitter, this.left, 0, 0);
+		Tone.connect(this._splitter, this.right, 1, 0);
 	};
 
 	Tone.extend(Tone.Split, Tone.AudioNode);

--- a/Tone/component/Volume.js
+++ b/Tone/component/Volume.js
@@ -10,7 +10,7 @@ define(["../core/Tone", "../signal/Signal", "../core/Gain", "../core/AudioNode"]
 	 *  @param {Decibels} [volume=0] the initial volume
 	 *  @example
 	 * var vol = new Tone.Volume(-12);
-	 * instrument.chain(vol, Tone.Master);
+	 * Tone.chain(instrument, vol, Tone.Master);
 	 */
 	Tone.Volume = function(){
 

--- a/Tone/core/AudioNode.js
+++ b/Tone/core/AudioNode.js
@@ -167,9 +167,9 @@ define(["../core/Tone", "../core/Context"], function(Tone){
 	Tone.AudioNode.prototype.connect = function(unit, outputNum, inputNum){
 		if (Tone.isArray(this.output)){
 			outputNum = Tone.defaultArg(outputNum, 0);
-			this.output[outputNum].connect(unit, 0, inputNum);
+			Tone.connect(this.output[outputNum], unit, 0, inputNum);
 		} else {
-			this.output.connect(unit, outputNum, inputNum);
+			Tone.connect(this.output, unit, outputNum, inputNum);
 		}
 		return this;
 	};
@@ -207,7 +207,7 @@ define(["../core/Tone", "../core/Context"], function(Tone){
 		var currentUnit = arguments[0];
 		for (var i = 1; i < arguments.length; i++){
 			var toUnit = arguments[i];
-			currentUnit.connect(toUnit);
+			Tone.connect(currentUnit, toUnit);
 			currentUnit = toUnit;
 		}
 		return arguments[0];
@@ -220,7 +220,7 @@ define(["../core/Tone", "../core/Context"], function(Tone){
 	 */
 	Tone.AudioNode.prototype.fan = function(){
 		for (var i = 0; i < arguments.length; i++){
-			this.connect(arguments[i]);
+			Tone.connect(this, arguments[i]);
 		}
 		return this;
 	};

--- a/Tone/core/AudioNode.js
+++ b/Tone/core/AudioNode.js
@@ -195,21 +195,22 @@ define(["../core/Tone", "../core/Context"], function(Tone){
 	};
 
 	/**
-	 *  Connect the output of this node to the rest of the nodes in series.
+	 *  Connect the output of the first node to the rest of the nodes in series.
+	 *  It returns the first node.
 	 *  @example
 	 *  //connect a node to an effect, panVol and then to the master output
-	 *  node.chain(effect, panVol, Tone.Master);
+	 *  Tone.chain(node, effect, panVol, Tone.Master);
 	 *  @param {...AudioParam|Tone|AudioNode} nodes
-	 *  @returns {Tone.AudioNode} this
+	 *  @returns {Tone.AudioNode}
 	 */
-	Tone.AudioNode.prototype.chain = function(){
-		var currentUnit = this;
-		for (var i = 0; i < arguments.length; i++){
+	Tone.chain = function(){
+		var currentUnit = arguments[0];
+		for (var i = 1; i < arguments.length; i++){
 			var toUnit = arguments[i];
 			currentUnit.connect(toUnit);
 			currentUnit = toUnit;
 		}
-		return this;
+		return arguments[0];
 	};
 
 	/**
@@ -225,8 +226,7 @@ define(["../core/Tone", "../core/Context"], function(Tone){
 	};
 
 	if (Tone.global.AudioNode){
-		//give native nodes chain and fan methods
-		AudioNode.prototype.chain = Tone.AudioNode.prototype.chain;
+		//give native nodes the fan method
 		AudioNode.prototype.fan = Tone.AudioNode.prototype.fan;
 	}
 

--- a/Tone/core/Bus.js
+++ b/Tone/core/Bus.js
@@ -32,8 +32,8 @@ define(["../core/Tone", "../core/Gain"], function(Tone){
 		}
 		amount = Tone.defaultArg(amount, 0);
 		var sendKnob = new Tone.Gain(amount, Tone.Type.Decibels);
-		this.connect(sendKnob);
-		sendKnob.connect(Buses[channelName]);
+		Tone.connect(this, sendKnob);
+		Tone.connect(sendKnob, Buses[channelName]);
 		return sendKnob;
 	};
 
@@ -50,7 +50,7 @@ define(["../core/Tone", "../core/Gain"], function(Tone){
 		if (!Buses.hasOwnProperty(channelName)){
 			Buses[channelName] = this.context.createGain();
 		}
-		Buses[channelName].connect(this, 0, inputNum);
+		Tone.connect(Buses[channelName], this, 0, inputNum);
 		return this;
 	};
 

--- a/Tone/core/Master.js
+++ b/Tone/core/Master.js
@@ -44,7 +44,7 @@ define(["../core/Tone", "../component/Volume", "../core/Context", "../core/Audio
 
 			this._readOnly("volume");
 			//connections
-			this.input.chain(this.output, this.context.destination);
+			Tone.chain(this.input, this.output, this.context.destination);
 
 			//master is a singleton so it adds itself to the context
 			this.context.master = this;
@@ -108,7 +108,7 @@ define(["../core/Tone", "../component/Volume", "../core/Context", "../core/Audio
 	 */
 	Tone.Master.prototype.chain = function(){
 		this.input.disconnect();
-		this.input.chain.apply(this.input, arguments);
+		Tone.chain([this.input].concat(arguments));
 		arguments[arguments.length - 1].connect(this.output);
 	};
 

--- a/Tone/core/Master.js
+++ b/Tone/core/Master.js
@@ -109,7 +109,7 @@ define(["../core/Tone", "../component/Volume", "../core/Context", "../core/Audio
 	Tone.Master.prototype.chain = function(){
 		this.input.disconnect();
 		Tone.chain([this.input].concat(arguments));
-		arguments[arguments.length - 1].connect(this.output);
+		Tone.connect(arguments[arguments.length - 1], this.output);
 	};
 
 	/**

--- a/Tone/core/Tone.js
+++ b/Tone/core/Tone.js
@@ -326,7 +326,7 @@ define(["../version"], function(version){
 		var currentUnit = arguments[0];
 		for (var i = 1; i < arguments.length; i++){
 			var toUnit = arguments[i];
-			currentUnit.connect(toUnit);
+			Tone.connect(currentUnit, toUnit);
 			currentUnit = toUnit;
 		}
 		return Tone;

--- a/Tone/core/Transport.js
+++ b/Tone/core/Transport.js
@@ -736,7 +736,7 @@ define(["../core/Tone", "../core/Clock", "../type/Type", "../core/Timeline",
 			}
 		}
 		var ratioSignal = new Tone.Gain(ratio);
-		this.bpm.chain(ratioSignal, signal._param);
+		Tone.chain(this.bpm, ratioSignal, signal._param);
 		this._syncedSignals.push({
 			"ratio" : ratioSignal,
 			"signal" : signal,

--- a/Tone/effect/AutoFilter.js
+++ b/Tone/effect/AutoFilter.js
@@ -63,7 +63,7 @@ define(["../core/Tone", "../effect/Effect", "../component/LFO", "../component/Fi
 
 		//connections
 		this.connectEffect(this.filter);
-		this._lfo.connect(this.filter.frequency);
+		Tone.connect(this._lfo, this.filter.frequency);
 		this.type = options.type;
 		this._readOnly(["frequency", "depth"]);
 		this.octaves = options.octaves;

--- a/Tone/effect/AutoPanner.js
+++ b/Tone/effect/AutoPanner.js
@@ -56,7 +56,7 @@ define(["../core/Tone", "../effect/Effect", "../component/LFO", "../component/Pa
 
 		//connections
 		this.connectEffect(this._panner);
-		this._lfo.connect(this._panner.pan);
+		Tone.connect(this._lfo, this._panner.pan);
 		this.type = options.type;
 		this._readOnly(["depth", "frequency"]);
 	};

--- a/Tone/effect/AutoWah.js
+++ b/Tone/effect/AutoWah.js
@@ -97,8 +97,8 @@ define(["../core/Tone", "../component/Follower", "../signal/ScaleExp",
 
 		//the control signal path
 		Tone.chain(this.effectSend, this._inputBoost, this.follower, this._sweepRange);
-		this._sweepRange.connect(this._bandpass.frequency);
-		this._sweepRange.connect(this._peaking.frequency);
+		Tone.connect(this._sweepRange, this._bandpass.frequency);
+		Tone.connect(this._sweepRange, this._peaking.frequency);
 		//the filtered path
 		Tone.chain(this.effectSend, this._bandpass, this._peaking, this.effectReturn);
 		//set the initial value

--- a/Tone/effect/AutoWah.js
+++ b/Tone/effect/AutoWah.js
@@ -96,11 +96,11 @@ define(["../core/Tone", "../component/Follower", "../signal/ScaleExp",
 		this.Q = this._bandpass.Q;
 
 		//the control signal path
-		this.effectSend.chain(this._inputBoost, this.follower, this._sweepRange);
+		Tone.chain(this.effectSend, this._inputBoost, this.follower, this._sweepRange);
 		this._sweepRange.connect(this._bandpass.frequency);
 		this._sweepRange.connect(this._peaking.frequency);
 		//the filtered path
-		this.effectSend.chain(this._bandpass, this._peaking, this.effectReturn);
+		Tone.chain(this.effectSend, this._bandpass, this._peaking, this.effectReturn);
 		//set the initial value
 		this._setSweepRange();
 		this.sensitivity = options.sensitivity;

--- a/Tone/effect/BitCrusher.js
+++ b/Tone/effect/BitCrusher.js
@@ -46,8 +46,8 @@ define(["../core/Tone", "../effect/Effect", "../signal/Subtract", "../signal/Mod
 
 		//connect it up
 		this.effectSend.fan(this._subtract, this._modulo);
-		this._modulo.connect(this._subtract, 0, 1);
-		this._subtract.connect(this.effectReturn);
+		Tone.connect(this._modulo, this._subtract, 0, 1);
+		Tone.connect(this._subtract, this.effectReturn);
 	};
 
 	Tone.extend(Tone.BitCrusher, Tone.Effect);

--- a/Tone/effect/Chorus.js
+++ b/Tone/effect/Chorus.js
@@ -82,8 +82,8 @@ define(["../core/Tone", "../component/LFO", "../effect/StereoEffect", "../core/D
 		this.frequency = this._lfoL.frequency;
 
 		//connections
-		this.effectSendL.chain(this._delayNodeL, this.effectReturnL);
-		this.effectSendR.chain(this._delayNodeR, this.effectReturnR);
+		Tone.chain(this.effectSendL, this._delayNodeL, this.effectReturnL);
+		Tone.chain(this.effectSendR, this._delayNodeR, this.effectReturnR);
 		//and pass through to make the detune apparent
 		this.effectSendL.connect(this.effectReturnL);
 		this.effectSendR.connect(this.effectReturnR);

--- a/Tone/effect/Chorus.js
+++ b/Tone/effect/Chorus.js
@@ -85,16 +85,16 @@ define(["../core/Tone", "../component/LFO", "../effect/StereoEffect", "../core/D
 		Tone.chain(this.effectSendL, this._delayNodeL, this.effectReturnL);
 		Tone.chain(this.effectSendR, this._delayNodeR, this.effectReturnR);
 		//and pass through to make the detune apparent
-		this.effectSendL.connect(this.effectReturnL);
-		this.effectSendR.connect(this.effectReturnR);
+		Tone.connect(this.effectSendL, this.effectReturnL);
+		Tone.connect(this.effectSendR, this.effectReturnR);
 		//lfo setup
-		this._lfoL.connect(this._delayNodeL.delayTime);
-		this._lfoR.connect(this._delayNodeR.delayTime);
+		Tone.connect(this._lfoL, this._delayNodeL.delayTime);
+		Tone.connect(this._lfoR, this._delayNodeR.delayTime);
 		//start the lfo
 		this._lfoL.start();
 		this._lfoR.start();
 		//have one LFO frequency control the other
-		this._lfoL.frequency.connect(this._lfoR.frequency);
+		Tone.connect(this._lfoL.frequency, this._lfoR.frequency);
 		//set the initial values
 		this.depth = this._depth;
 		this.frequency.value = options.frequency;

--- a/Tone/effect/Effect.js
+++ b/Tone/effect/Effect.js
@@ -72,7 +72,7 @@ define(["../core/Tone", "../component/CrossFade", "../core/AudioNode"], function
 	 *  @returns {Tone.Effect} this
 	 */
 	Tone.Effect.prototype.connectEffect = function(effect){
-		this.effectSend.chain(effect, this.effectReturn);
+		Tone.chain(this.effectSend, effect, this.effectReturn);
 		return this;
 	};
 

--- a/Tone/effect/Effect.js
+++ b/Tone/effect/Effect.js
@@ -48,10 +48,10 @@ define(["../core/Tone", "../component/CrossFade", "../core/AudioNode"], function
 		this.effectReturn = new Tone.Gain();
 
 		//connections
-		this.input.connect(this._dryWet.a);
-		this.input.connect(this.effectSend);
-		this.effectReturn.connect(this._dryWet.b);
-		this._dryWet.connect(this.output);
+		Tone.connect(this.input, this._dryWet.a);
+		Tone.connect(this.input, this.effectSend);
+		Tone.connect(this.effectReturn, this._dryWet.b);
+		Tone.connect(this._dryWet, this.output);
 		this._readOnly(["wet"]);
 	};
 

--- a/Tone/effect/FeedbackEffect.js
+++ b/Tone/effect/FeedbackEffect.js
@@ -32,7 +32,7 @@ define(["../core/Tone", "../effect/Effect", "../signal/Signal",
 		this.feedback = this._feedbackGain.gain;
 
 		//the feedback loop
-		this.effectReturn.chain(this._feedbackGain, this.effectSend);
+		Tone.chain(this.effectReturn, this._feedbackGain, this.effectSend);
 		this._readOnly(["feedback"]);
 	};
 

--- a/Tone/effect/Freeverb.js
+++ b/Tone/effect/Freeverb.js
@@ -99,16 +99,16 @@ define(["../core/Tone", "../component/LowpassCombFilter", "../effect/StereoEffec
 			} else {
 				Tone.chain(this.effectSendR, lfpf, this._allpassFiltersR[0]);
 			}
-			this.roomSize.connect(lfpf.resonance);
-			this.dampening.connect(lfpf.dampening);
+			Tone.connect(this.roomSize, lfpf.resonance);
+			Tone.connect(this.dampening, lfpf.dampening);
 			this._combFilters.push(lfpf);
 		}
 
 		//chain the allpass filters togetehr
 		Tone.connectSeries.apply(Tone, this._allpassFiltersL);
 		Tone.connectSeries.apply(Tone, this._allpassFiltersR);
-		this._allpassFiltersL[this._allpassFiltersL.length - 1].connect(this.effectReturnL);
-		this._allpassFiltersR[this._allpassFiltersR.length - 1].connect(this.effectReturnR);
+		Tone.connect(this._allpassFiltersL[this._allpassFiltersL.length - 1], this.effectReturnL);
+		Tone.connect(this._allpassFiltersR[this._allpassFiltersR.length - 1], this.effectReturnR);
 		this._readOnly(["roomSize", "dampening"]);
 	};
 

--- a/Tone/effect/Freeverb.js
+++ b/Tone/effect/Freeverb.js
@@ -95,9 +95,9 @@ define(["../core/Tone", "../component/LowpassCombFilter", "../effect/StereoEffec
 		for (var c = 0; c < combFilterTunings.length; c++){
 			var lfpf = new Tone.LowpassCombFilter(combFilterTunings[c]);
 			if (c < combFilterTunings.length / 2){
-				this.effectSendL.chain(lfpf, this._allpassFiltersL[0]);
+				Tone.chain(this.effectSendL, lfpf, this._allpassFiltersL[0]);
 			} else {
-				this.effectSendR.chain(lfpf, this._allpassFiltersR[0]);
+				Tone.chain(this.effectSendR, lfpf, this._allpassFiltersR[0]);
 			}
 			this.roomSize.connect(lfpf.resonance);
 			this.dampening.connect(lfpf.dampening);

--- a/Tone/effect/JCReverb.js
+++ b/Tone/effect/JCReverb.js
@@ -39,7 +39,7 @@ define(["../core/Tone", "../component/FeedbackCombFilter", "../effect/StereoEffe
 	 * var reverb = new Tone.JCReverb(0.4).connect(Tone.Master);
 	 * var delay = new Tone.FeedbackDelay(0.5);
 	 * //connecting the synth to reverb through delay
-	 * var synth = new Tone.DuoSynth().chain(delay, reverb);
+	 * var synth = Tone.chain(new Tone.DuoSynth(), delay, reverb);
 	 * synth.triggerAttackRelease("A4","8n");
 	 */
 	Tone.JCReverb = function(){

--- a/Tone/effect/JCReverb.js
+++ b/Tone/effect/JCReverb.js
@@ -86,22 +86,22 @@ define(["../core/Tone", "../component/FeedbackCombFilter", "../effect/StereoEffe
 		//and the comb filters
 		for (var cf = 0; cf < combFilterDelayTimes.length; cf++){
 			var fbcf = new Tone.FeedbackCombFilter(combFilterDelayTimes[cf], 0.1);
-			this._scaleRoomSize.connect(fbcf.resonance);
+			Tone.connect(this._scaleRoomSize, fbcf.resonance);
 			fbcf.resonance.value = combFilterResonances[cf];
-			this._allpassFilters[this._allpassFilters.length - 1].connect(fbcf);
+			Tone.connect(this._allpassFilters[this._allpassFilters.length - 1], fbcf);
 			if (cf < combFilterDelayTimes.length / 2){
-				fbcf.connect(this.effectReturnL);
+				Tone.connect(fbcf, this.effectReturnL);
 			} else {
-				fbcf.connect(this.effectReturnR);
+				Tone.connect(fbcf, this.effectReturnR);
 			}
 			this._feedbackCombFilters.push(fbcf);
 		}
 
 		//chain the allpass filters together
-		this.roomSize.connect(this._scaleRoomSize);
+		Tone.connect(this.roomSize, this._scaleRoomSize);
 		Tone.connectSeries.apply(Tone, this._allpassFilters);
-		this.effectSendL.connect(this._allpassFilters[0]);
-		this.effectSendR.connect(this._allpassFilters[0]);
+		Tone.connect(this.effectSendL, this._allpassFilters[0]);
+		Tone.connect(this.effectSendR, this._allpassFilters[0]);
 		this._readOnly(["roomSize"]);
 	};
 

--- a/Tone/effect/MidSideEffect.js
+++ b/Tone/effect/MidSideEffect.js
@@ -62,8 +62,8 @@ define(["../core/Tone", "../effect/Effect", "../component/MidSideSplit", "../com
 		this.sideReturn = this._midSideMerge.side;
 
 		//the connections
-		this.effectSend.connect(this._midSideSplit);
-		this._midSideMerge.connect(this.effectReturn);
+		Tone.connect(this.effectSend, this._midSideSplit);
+		Tone.connect(this._midSideMerge, this.effectReturn);
 	};
 
 	Tone.extend(Tone.MidSideEffect, Tone.Effect);

--- a/Tone/effect/Phaser.js
+++ b/Tone/effect/Phaser.js
@@ -86,12 +86,12 @@ define(["../core/Tone", "../component/LFO", "../component/Filter", "../effect/St
 		this.frequency.value = options.frequency;
 
 		//connect them up
-		this.effectSendL.connect(this._filtersL[0]);
-		this.effectSendR.connect(this._filtersR[0]);
-		this._filtersL[options.stages - 1].connect(this.effectReturnL);
-		this._filtersR[options.stages - 1].connect(this.effectReturnR);
+		Tone.connect(this.effectSendL, this._filtersL[0]);
+		Tone.connect(this.effectSendR, this._filtersR[0]);
+		Tone.connect(this._filtersL[options.stages - 1], this.effectReturnL);
+		Tone.connect(this._filtersR[options.stages - 1], this.effectReturnR);
 		//control the frequency with one LFO
-		this._lfoL.frequency.connect(this._lfoR.frequency);
+		Tone.connect(this._lfoL.frequency, this._lfoR.frequency);
 		//set the options
 		this.baseFrequency = options.baseFrequency;
 		this.octaves = options.octaves;
@@ -127,8 +127,8 @@ define(["../core/Tone", "../component/LFO", "../component/Filter", "../effect/St
 		for (var i = 0; i < stages; i++){
 			var filter = this.context.createBiquadFilter();
 			filter.type = "allpass";
-			Q.connect(filter.Q);
-			connectToFreq.connect(filter.frequency);
+			Tone.connect(Q, filter.Q);
+			Tone.connect(connectToFreq, filter.frequency);
 			filters[i] = filter;
 		}
 		Tone.connectSeries.apply(Tone, filters);

--- a/Tone/effect/PingPongDelay.js
+++ b/Tone/effect/PingPongDelay.js
@@ -60,7 +60,7 @@ define(["../core/Tone", "../effect/StereoXFeedbackEffect", "../signal/Signal", "
 		this.delayTime.fan(this._leftDelay.delayTime, this._rightDelay.delayTime, this._rightPreDelay.delayTime);
 		//rearranged the feedback to be after the rightPreDelay
 		this._feedbackLR.disconnect();
-		this._feedbackLR.connect(this._rightDelay);
+		Tone.connect(this._feedbackLR, this._rightDelay);
 		this._readOnly(["delayTime"]);
 	};
 

--- a/Tone/effect/PingPongDelay.js
+++ b/Tone/effect/PingPongDelay.js
@@ -55,8 +55,8 @@ define(["../core/Tone", "../effect/StereoXFeedbackEffect", "../signal/Signal", "
 		this.delayTime = new Tone.Signal(options.delayTime, Tone.Type.Time);
 
 		//connect it up
-		this.effectSendL.chain(this._leftDelay, this.effectReturnL);
-		this.effectSendR.chain(this._rightPreDelay, this._rightDelay, this.effectReturnR);
+		Tone.chain(this.effectSendL, this._leftDelay, this.effectReturnL);
+		Tone.chain(this.effectSendR, this._rightPreDelay, this._rightDelay, this.effectReturnR);
 		this.delayTime.fan(this._leftDelay.delayTime, this._rightDelay.delayTime, this._rightPreDelay.delayTime);
 		//rearranged the feedback to be after the rightPreDelay
 		this._feedbackLR.disconnect();

--- a/Tone/effect/PitchShift.js
+++ b/Tone/effect/PitchShift.js
@@ -121,7 +121,7 @@ define(["../core/Tone", "../component/LFO", "../component/CrossFade",
 		this._frequency.fan(this._lfoA.frequency, this._lfoB.frequency, this._crossFadeLFO.frequency);
 		//route the input
 		this.effectSend.fan(this._delayA, this._delayB);
-		this._crossFade.chain(this._feedbackDelay, this.effectReturn);
+		Tone.chain(this._crossFade, this._feedbackDelay, this.effectReturn);
 		//start the LFOs at the same time
 		var now = this.now();
 		this._lfoA.start(now);

--- a/Tone/effect/PitchShift.js
+++ b/Tone/effect/PitchShift.js
@@ -42,7 +42,8 @@ define(["../core/Tone", "../component/LFO", "../component/CrossFade",
 			"min" : 0,
 			"max" : 0.1,
 			"type" : "sawtooth"
-		}).connect(this._delayA.delayTime);
+		});
+		Tone.connect(this._lfoA, this._delayA.delayTime);
 
 		/**
 		 *  The second DelayNode
@@ -61,7 +62,8 @@ define(["../core/Tone", "../component/LFO", "../component/CrossFade",
 			"max" : 0.1,
 			"type" : "sawtooth",
 			"phase" : 180
-		}).connect(this._delayB.delayTime);
+		});
+		Tone.connect(this._lfoB, this._delayB.delayTime);
 
 		/**
 		 *  Crossfade quickly between the two delay lines
@@ -83,7 +85,8 @@ define(["../core/Tone", "../component/LFO", "../component/CrossFade",
 			"max" : 1,
 			"type" : "triangle",
 			"phase" : 90
-		}).connect(this._crossFade.fade);
+		});
+		Tone.connect(this._crossFadeLFO, this._crossFade.fade);
 
 		/**
 		 *  The delay node
@@ -115,8 +118,8 @@ define(["../core/Tone", "../component/LFO", "../component/CrossFade",
 		this._windowSize = options.windowSize;
 
 		//connect the two delay lines up
-		this._delayA.connect(this._crossFade.a);
-		this._delayB.connect(this._crossFade.b);
+		Tone.connect(this._delayA, this._crossFade.a);
+		Tone.connect(this._delayB, this._crossFade.b);
 		//connect the frequency
 		this._frequency.fan(this._lfoA.frequency, this._lfoB.frequency, this._crossFadeLFO.frequency);
 		//route the input

--- a/Tone/effect/Reverb.js
+++ b/Tone/effect/Reverb.js
@@ -67,10 +67,10 @@ define(["../core/Tone", "../core/Offline", "../component/Filter", "../component/
 			var noiseL = new Tone.Noise();
 			var noiseR = new Tone.Noise();
 			var merge = new Tone.Merge();
-			noiseL.connect(merge.left);
-			noiseR.connect(merge.right);
+			Tone.connect(noiseL, merge.left);
+			Tone.connect(noiseR, merge.right);
 			var gainNode = new Tone.Gain().toMaster();
-			merge.connect(gainNode);
+			Tone.connect(merge, gainNode);
 			noiseL.start(0);
 			noiseR.start(0);
 			//short fade in

--- a/Tone/effect/StereoEffect.js
+++ b/Tone/effect/StereoEffect.js
@@ -74,11 +74,11 @@ define(["../core/Tone", "../effect/Effect", "../component/Split",
 		this.effectReturnR = this._merge.right;
 
 		//connections
-		this.input.connect(this._split);
+		Tone.connect(this.input, this._split);
 		//dry wet connections
-		this.input.connect(this._dryWet, 0, 0);
-		this._merge.connect(this._dryWet, 0, 1);
-		this._dryWet.connect(this.output);
+		Tone.connect(this.input, this._dryWet, 0, 0);
+		Tone.connect(this._merge, this._dryWet, 0, 1);
+		Tone.connect(this._dryWet, this.output);
 		this._readOnly(["wet"]);
 	};
 

--- a/Tone/effect/StereoFeedbackEffect.js
+++ b/Tone/effect/StereoFeedbackEffect.js
@@ -36,8 +36,8 @@ define(["../core/Tone", "../effect/StereoEffect", "../effect/FeedbackEffect", ".
 		this._feedbackR = new Tone.Gain();
 
 		//connect it up
-		this.effectReturnL.chain(this._feedbackL, this.effectSendL);
-		this.effectReturnR.chain(this._feedbackR, this.effectSendR);
+		Tone.chain(this.effectReturnL, this._feedbackL, this.effectSendL);
+		Tone.chain(this.effectReturnR, this._feedbackR, this.effectSendR);
 		this.feedback.fan(this._feedbackL.gain, this._feedbackR.gain);
 		this._readOnly(["feedback"]);
 	};

--- a/Tone/effect/StereoWidener.js
+++ b/Tone/effect/StereoWidener.js
@@ -50,7 +50,7 @@ define(["../core/Tone", "../effect/MidSideEffect", "../signal/Signal",
 		 *  @private
 		 */
 		this._midMult = new Tone.Multiply();
-		this._twoTimesWidthMid.connect(this._midMult, 0, 1);
+		Tone.connect(this._twoTimesWidthMid, this._midMult, 0, 1);
 		Tone.chain(this.midSend, this._midMult, this.midReturn);
 
 		/**
@@ -58,9 +58,9 @@ define(["../core/Tone", "../effect/MidSideEffect", "../signal/Signal",
 		 * @type {Tone}
 		 */
 		this._oneMinusWidth = new Tone.Subtract();
-		this._oneMinusWidth.connect(this._twoTimesWidthMid);
-		this.context.getConstant(1).connect(this._oneMinusWidth, 0, 0);
-		this.width.connect(this._oneMinusWidth, 0, 1);
+		Tone.connect(this._oneMinusWidth, this._twoTimesWidthMid);
+		Tone.connect(this.context.getConstant(1), this._oneMinusWidth, 0, 0);
+		Tone.connect(this.width, this._oneMinusWidth, 0, 1);
 
 		/**
 		 *  Side multiplier
@@ -68,8 +68,8 @@ define(["../core/Tone", "../effect/MidSideEffect", "../signal/Signal",
 		 *  @private
 		 */
 		this._sideMult = new Tone.Multiply();
-		this.width.connect(this._twoTimesWidthSide);
-		this._twoTimesWidthSide.connect(this._sideMult, 0, 1);
+		Tone.connect(this.width, this._twoTimesWidthSide);
+		Tone.connect(this._twoTimesWidthSide, this._sideMult, 0, 1);
 		Tone.chain(this.sideSend, this._sideMult, this.sideReturn);
 	};
 

--- a/Tone/effect/StereoWidener.js
+++ b/Tone/effect/StereoWidener.js
@@ -51,7 +51,7 @@ define(["../core/Tone", "../effect/MidSideEffect", "../signal/Signal",
 		 */
 		this._midMult = new Tone.Multiply();
 		this._twoTimesWidthMid.connect(this._midMult, 0, 1);
-		this.midSend.chain(this._midMult, this.midReturn);
+		Tone.chain(this.midSend, this._midMult, this.midReturn);
 
 		/**
 		 * 1 - width
@@ -70,7 +70,7 @@ define(["../core/Tone", "../effect/MidSideEffect", "../signal/Signal",
 		this._sideMult = new Tone.Multiply();
 		this.width.connect(this._twoTimesWidthSide);
 		this._twoTimesWidthSide.connect(this._sideMult, 0, 1);
-		this.sideSend.chain(this._sideMult, this.sideReturn);
+		Tone.chain(this.sideSend, this._sideMult, this.sideReturn);
 	};
 
 	Tone.extend(Tone.StereoWidener, Tone.MidSideEffect);

--- a/Tone/effect/StereoXFeedbackEffect.js
+++ b/Tone/effect/StereoXFeedbackEffect.js
@@ -38,8 +38,8 @@ define(["../core/Tone", "../effect/StereoEffect", "../effect/FeedbackEffect"], f
 		this._feedbackRL = new Tone.Gain();
 
 		//connect it up
-		this.effectReturnL.chain(this._feedbackLR, this.effectSendR);
-		this.effectReturnR.chain(this._feedbackRL, this.effectSendL);
+		Tone.chain(this.effectReturnL, this._feedbackLR, this.effectSendR);
+		Tone.chain(this.effectReturnR, this._feedbackRL, this.effectSendL);
 		this.feedback.fan(this._feedbackLR.gain, this._feedbackRL.gain);
 		this._readOnly(["feedback"]);
 	};

--- a/Tone/effect/Tremolo.js
+++ b/Tone/effect/Tremolo.js
@@ -76,8 +76,8 @@ define(["../core/Tone", "../component/LFO", "../effect/StereoEffect"], function(
 		this._readOnly(["frequency", "depth"]);
 		Tone.chain(this.effectSendL, this._amplitudeL, this.effectReturnL);
 		Tone.chain(this.effectSendR, this._amplitudeR, this.effectReturnR);
-		this._lfoL.connect(this._amplitudeL.gain);
-		this._lfoR.connect(this._amplitudeR.gain);
+		Tone.connect(this._lfoL, this._amplitudeL.gain);
+		Tone.connect(this._lfoR, this._amplitudeR.gain);
 		this.frequency.fan(this._lfoL.frequency, this._lfoR.frequency);
 		this.depth.fan(this._lfoR.amplitude, this._lfoL.amplitude);
 		this.type = options.type;

--- a/Tone/effect/Tremolo.js
+++ b/Tone/effect/Tremolo.js
@@ -74,8 +74,8 @@ define(["../core/Tone", "../component/LFO", "../effect/StereoEffect"], function(
 		this.depth = new Tone.Signal(options.depth, Tone.Type.NormalRange);
 
 		this._readOnly(["frequency", "depth"]);
-		this.effectSendL.chain(this._amplitudeL, this.effectReturnL);
-		this.effectSendR.chain(this._amplitudeR, this.effectReturnR);
+		Tone.chain(this.effectSendL, this._amplitudeL, this.effectReturnL);
+		Tone.chain(this.effectSendR, this._amplitudeR, this.effectReturnR);
 		this._lfoL.connect(this._amplitudeL.gain);
 		this._lfoR.connect(this._amplitudeR.gain);
 		this.frequency.fan(this._lfoL.frequency, this._lfoR.frequency);

--- a/Tone/effect/Vibrato.js
+++ b/Tone/effect/Vibrato.js
@@ -33,7 +33,8 @@ define(["../core/Tone", "../effect/Effect", "../core/Delay", "../component/LFO"]
 			"max" : options.maxDelay, 
 			"frequency" : options.frequency,
 			"phase" : -90 //offse the phase so the resting position is in the center
-		}).start().connect(this._delayNode.delayTime);
+		}).start();
+		Tone.connect(this._lfo, this._delayNode.delayTime);
 
 		/**
 		 *  The frequency of the vibrato

--- a/Tone/effect/Vibrato.js
+++ b/Tone/effect/Vibrato.js
@@ -51,7 +51,7 @@ define(["../core/Tone", "../effect/Effect", "../core/Delay", "../component/LFO"]
 
 		this.depth.value = options.depth;
 		this._readOnly(["frequency", "depth"]);
-		this.effectSend.chain(this._delayNode, this.effectReturn);
+		Tone.chain(this.effectSend, this._delayNode, this.effectReturn);
 	};
 
 	Tone.extend(Tone.Vibrato, Tone.Effect);

--- a/Tone/instrument/AMSynth.js
+++ b/Tone/instrument/AMSynth.js
@@ -107,10 +107,10 @@ define(["../core/Tone", "../instrument/Synth", "../signal/Signal", "../signal/Mu
 
 		//control the two voices frequency
 		this.frequency.connect(this._carrier.frequency);
-		this.frequency.chain(this.harmonicity, this._modulator.frequency);
+		Tone.chain(this.frequency, this.harmonicity, this._modulator.frequency);
 		this.detune.fan(this._carrier.detune, this._modulator.detune);
-		this._modulator.chain(this._modulationScale, this._modulationNode.gain);
-		this._carrier.chain(this._modulationNode, this.output);
+		Tone.chain(this._modulator, this._modulationScale, this._modulationNode.gain);
+		Tone.chain(this._carrier, this._modulationNode, this.output);
 		this._readOnly(["frequency", "harmonicity", "oscillator", "envelope", "modulation", "modulationEnvelope", "detune"]);
 	};
 

--- a/Tone/instrument/AMSynth.js
+++ b/Tone/instrument/AMSynth.js
@@ -106,7 +106,7 @@ define(["../core/Tone", "../instrument/Synth", "../signal/Signal", "../signal/Mu
 		this._modulationNode = new Tone.Gain();
 
 		//control the two voices frequency
-		this.frequency.connect(this._carrier.frequency);
+		Tone.connect(this.frequency, this._carrier.frequency);
 		Tone.chain(this.frequency, this.harmonicity, this._modulator.frequency);
 		this.detune.fan(this._carrier.detune, this._modulator.detune);
 		Tone.chain(this._modulator, this._modulationScale, this._modulationNode.gain);

--- a/Tone/instrument/DuoSynth.js
+++ b/Tone/instrument/DuoSynth.js
@@ -86,7 +86,7 @@ define(["../core/Tone", "../instrument/MonoSynth", "../component/LFO", "../signa
 
 		//control the two voices frequency
 		this.frequency.connect(this.voice0.frequency);
-		this.frequency.chain(this.harmonicity, this.voice1.frequency);
+		Tone.chain(this.frequency, this.harmonicity, this.voice1.frequency);
 		this._vibrato.connect(this._vibratoGain);
 		this._vibratoGain.fan(this.voice0.detune, this.voice1.detune);
 		this.voice0.connect(this.output);

--- a/Tone/instrument/DuoSynth.js
+++ b/Tone/instrument/DuoSynth.js
@@ -85,12 +85,12 @@ define(["../core/Tone", "../instrument/MonoSynth", "../component/LFO", "../signa
 		this.harmonicity.units = Tone.Type.Positive;
 
 		//control the two voices frequency
-		this.frequency.connect(this.voice0.frequency);
+		Tone.connect(this.frequency, this.voice0.frequency);
 		Tone.chain(this.frequency, this.harmonicity, this.voice1.frequency);
-		this._vibrato.connect(this._vibratoGain);
+		Tone.connect(this._vibrato, this._vibratoGain);
 		this._vibratoGain.fan(this.voice0.detune, this.voice1.detune);
-		this.voice0.connect(this.output);
-		this.voice1.connect(this.output);
+		Tone.connect(this.voice0, this.output);
+		Tone.connect(this.voice1, this.output);
 		this._readOnly(["voice0", "voice1", "frequency", "vibratoAmount", "vibratoRate"]);
 	};
 

--- a/Tone/instrument/FMSynth.js
+++ b/Tone/instrument/FMSynth.js
@@ -108,13 +108,13 @@ define(["../core/Tone", "../instrument/Synth", "../signal/Signal", "../signal/Mu
 		this._modulationNode = new Tone.Gain(0);
 
 		//control the two voices frequency
-		this.frequency.connect(this._carrier.frequency);
+		Tone.connect(this.frequency, this._carrier.frequency);
 		Tone.chain(this.frequency, this.harmonicity, this._modulator.frequency);
 		Tone.chain(this.frequency, this.modulationIndex, this._modulationNode);
 		this.detune.fan(this._carrier.detune, this._modulator.detune);
-		this._modulator.connect(this._modulationNode.gain);
-		this._modulationNode.connect(this._carrier.frequency);
-		this._carrier.connect(this.output);
+		Tone.connect(this._modulator, this._modulationNode.gain);
+		Tone.connect(this._modulationNode, this._carrier.frequency);
+		Tone.connect(this._carrier, this.output);
 		this._readOnly(["frequency", "harmonicity", "modulationIndex", "oscillator", "envelope", "modulation", "modulationEnvelope", "detune"]);
 	};
 

--- a/Tone/instrument/FMSynth.js
+++ b/Tone/instrument/FMSynth.js
@@ -109,8 +109,8 @@ define(["../core/Tone", "../instrument/Synth", "../signal/Signal", "../signal/Mu
 
 		//control the two voices frequency
 		this.frequency.connect(this._carrier.frequency);
-		this.frequency.chain(this.harmonicity, this._modulator.frequency);
-		this.frequency.chain(this.modulationIndex, this._modulationNode);
+		Tone.chain(this.frequency, this.harmonicity, this._modulator.frequency);
+		Tone.chain(this.frequency, this.modulationIndex, this._modulationNode);
 		this.detune.fan(this._carrier.detune, this._modulator.detune);
 		this._modulator.connect(this._modulationNode.gain);
 		this._modulationNode.connect(this._carrier.frequency);

--- a/Tone/instrument/MembraneSynth.js
+++ b/Tone/instrument/MembraneSynth.js
@@ -49,7 +49,7 @@ define(["../core/Tone", "../source/OmniOscillator", "../instrument/Instrument",
 		 */
 		this.pitchDecay = options.pitchDecay;
 
-		this.oscillator.chain(this.envelope, this.output);
+		Tone.chain(this.oscillator, this.envelope, this.output);
 		this._readOnly(["oscillator", "envelope"]);
 	};
 

--- a/Tone/instrument/MetalSynth.js
+++ b/Tone/instrument/MetalSynth.js
@@ -86,13 +86,13 @@ define(["../core/Tone", "../instrument/Instrument", "../source/FMOscillator", ".
 		 *  amplitude and highpass filter's cutoff frequency
 		 *  @type  {Tone.Envelope}
 		 */
-		this.envelope = new Tone.Envelope({
+		this.envelope = Tone.chain(new Tone.Envelope({
 			"attack" : options.envelope.attack,
 			"attackCurve" : "linear",
 			"decay" : options.envelope.decay,
 			"sustain" : 0,
 			"release" : options.envelope.release,
-		}).chain(this._filterFreqScaler, this._highpass.frequency);
+		}), this._filterFreqScaler, this._highpass.frequency);
 		this.envelope.connect(this._amplitue.gain);
 
 		for (var i = 0; i < inharmRatios.length; i++){
@@ -107,7 +107,7 @@ define(["../core/Tone", "../instrument/Instrument", "../source/FMOscillator", ".
 
 			var mult = new Tone.Multiply(inharmRatios[i]);
 			this._freqMultipliers[i] = mult;
-			this.frequency.chain(mult, osc.frequency);
+			Tone.chain(this.frequency, mult, osc.frequency);
 		}
 
 		//set the octaves

--- a/Tone/instrument/MetalSynth.js
+++ b/Tone/instrument/MetalSynth.js
@@ -53,7 +53,8 @@ define(["../core/Tone", "../instrument/Instrument", "../source/FMOscillator", ".
 		 *  @type {Tone.Gain}
 		 *  @private
 		 */
-		this._amplitue = new Tone.Gain(0).connect(this.output);
+		this._amplitue = new Tone.Gain(0);
+		Tone.connect(this._amplitue, this.output);
 
 		/**
 		 *  highpass the output
@@ -63,7 +64,8 @@ define(["../core/Tone", "../instrument/Instrument", "../source/FMOscillator", ".
 		this._highpass = new Tone.Filter({
 			"type" : "highpass",
 			"Q" : -3.0102999566398125
-		}).connect(this._amplitue);
+		});
+		Tone.connect(this._highpass, this._amplitue);
 
 		/**
 		 *  The number of octaves the highpass
@@ -93,7 +95,7 @@ define(["../core/Tone", "../instrument/Instrument", "../source/FMOscillator", ".
 			"sustain" : 0,
 			"release" : options.envelope.release,
 		}), this._filterFreqScaler, this._highpass.frequency);
-		this.envelope.connect(this._amplitue.gain);
+		Tone.connect(this.envelope, this._amplitue.gain);
 
 		for (var i = 0; i < inharmRatios.length; i++){
 			var osc = new Tone.FMOscillator({
@@ -102,7 +104,7 @@ define(["../core/Tone", "../instrument/Instrument", "../source/FMOscillator", ".
 				"harmonicity" : options.harmonicity,
 				"modulationIndex" : options.modulationIndex
 			});
-			osc.connect(this._highpass);
+			Tone.connect(osc, this._highpass);
 			this._oscillators[i] = osc;
 
 			var mult = new Tone.Multiply(inharmRatios[i]);

--- a/Tone/instrument/MonoSynth.js
+++ b/Tone/instrument/MonoSynth.js
@@ -71,7 +71,7 @@ define(["../core/Tone", "../component/AmplitudeEnvelope", "../component/Frequenc
 		//connect the oscillators to the output
 		Tone.chain(this.oscillator, this.filter, this.envelope, this.output);
 		//connect the filter envelope
-		this.filterEnvelope.connect(this.filter.frequency);
+		Tone.connect(this.filterEnvelope, this.filter.frequency);
 		this._readOnly(["oscillator", "frequency", "detune", "filter", "filterEnvelope", "envelope"]);
 	};
 

--- a/Tone/instrument/MonoSynth.js
+++ b/Tone/instrument/MonoSynth.js
@@ -69,7 +69,7 @@ define(["../core/Tone", "../component/AmplitudeEnvelope", "../component/Frequenc
 		this.envelope = new Tone.AmplitudeEnvelope(options.envelope);
 
 		//connect the oscillators to the output
-		this.oscillator.chain(this.filter, this.envelope, this.output);
+		Tone.chain(this.oscillator, this.filter, this.envelope, this.output);
 		//connect the filter envelope
 		this.filterEnvelope.connect(this.filter.frequency);
 		this._readOnly(["oscillator", "frequency", "detune", "filter", "filterEnvelope", "envelope"]);

--- a/Tone/instrument/NoiseSynth.js
+++ b/Tone/instrument/NoiseSynth.js
@@ -38,7 +38,7 @@ define(["../core/Tone", "../component/AmplitudeEnvelope", "../component/Frequenc
 		this.envelope = new Tone.AmplitudeEnvelope(options.envelope);
 
 		//connect the noise to the output
-		this.noise.chain(this.envelope, this.output);
+		Tone.chain(this.noise, this.envelope, this.output);
 		this._readOnly(["noise", "envelope"]);
 	};
 

--- a/Tone/instrument/PluckSynth.js
+++ b/Tone/instrument/PluckSynth.js
@@ -57,8 +57,8 @@ define(["../core/Tone", "../instrument/Instrument", "../source/Noise", "../compo
 		this.dampening = this._lfcf.dampening;
 
 		//connections
-		this._noise.connect(this._lfcf);
-		this._lfcf.connect(this.output);
+		Tone.connect(this._noise, this._lfcf);
+		Tone.connect(this._lfcf, this.output);
 		this._readOnly(["resonance", "dampening"]);
 	};
 

--- a/Tone/instrument/PolySynth.js
+++ b/Tone/instrument/PolySynth.js
@@ -54,9 +54,9 @@ define(["../core/Tone", "../instrument/Synth", "../source/Source"], function(Ton
 			}
 			this.voices[i] = v;
 			v.index = i;
-			v.connect(this.output);
+			Tone.connect(v, this.output);
 			if (v.hasOwnProperty("detune")){
-				this.detune.connect(v.detune);
+				Tone.connect(this.detune, v.detune);
 			}
 		}
 	};

--- a/Tone/instrument/Sampler.js
+++ b/Tone/instrument/Sampler.js
@@ -139,7 +139,8 @@ define(["../core/Tone", "../instrument/Instrument", "../core/Buffers", "../sourc
 					"fadeIn" : this.attack,
 					"fadeOut" : this.release,
 					"curve" : this.curve,
-				}).connect(this.output);
+				});
+				Tone.connect(source, this.output);
 				source.start(time, 0, buffer.duration / playbackRate, velocity);
 				// add it to the active sources
 				if (!Tone.isArray(this._activeSources[midi])){

--- a/Tone/instrument/Synth.js
+++ b/Tone/instrument/Synth.js
@@ -49,7 +49,7 @@ define(["../core/Tone", "../component/AmplitudeEnvelope", "../source/OmniOscilla
 		this.envelope = new Tone.AmplitudeEnvelope(options.envelope);
 
 		//connect the oscillators to the output
-		this.oscillator.chain(this.envelope, this.output);
+		Tone.chain(this.oscillator, this.envelope, this.output);
 		this._readOnly(["oscillator", "frequency", "detune", "envelope"]);
 	};
 

--- a/Tone/shim/AudioContext.js
+++ b/Tone/shim/AudioContext.js
@@ -22,7 +22,7 @@ define(["../core/Tone", "../shim/OfflineAudioContext"], function(Tone){
 				var buffer = this.createBuffer(1, 1, this.sampleRate);
 				var source = this.createBufferSource();
 				source.buffer = buffer;
-				source.connect(this.destination);
+				Tone.connect(source, this.destination);
 				source.start(0);
 				return Promise.resolve();
 			};

--- a/Tone/shim/ConstantSourceNode.js
+++ b/Tone/shim/ConstantSourceNode.js
@@ -21,7 +21,7 @@ define(["../core/Tone", "../shim/AudioContext", "../shim/BufferSourceNode",
 			var gainNode = this._output = context.createGain();
 			this.offset = gainNode.gain;
 
-			this._bufferSource.connect(gainNode);
+			Tone.connect(this._bufferSource, gainNode);
 		};
 
 		ConstantSourceNode.prototype.start = function(time){

--- a/Tone/shim/StereoPannerNode.js
+++ b/Tone/shim/StereoPannerNode.js
@@ -79,10 +79,10 @@ define(["../core/Tone", "../signal/WaveShaper", "../component/Merge", "../signal
 			var merge = this.output = new Tone.Merge();
 
 			//connections
-			split.left.chain(leftGain, merge.left);
-			split.right.chain(rightGain, merge.right);
-			this.pan.chain(leftWaveShaper, leftGain.gain);
-			this.pan.chain(rightWaveShaper, rightGain.gain);
+			Tone.chain(split.left, leftGain, merge.left);
+			Tone.chain(split.right, rightGain, merge.right);
+			Tone.chain(this.pan, leftWaveShaper, leftGain.gain);
+			Tone.chain(this.pan, rightWaveShaper, rightGain.gain);
 		};
 
 		StereoPannerNode.prototype.disconnect = function(){

--- a/Tone/signal/Add.js
+++ b/Tone/signal/Add.js
@@ -43,7 +43,7 @@ define(["../core/Tone", "../signal/Signal", "../core/Gain"], function(Tone){
 		 */
 		this._param = this.input[1] = new Tone.Signal(value);
 
-		this._param.connect(this._sum);
+		Tone.connect(this._param, this._sum);
 		this.proxy = false;
 	};
 

--- a/Tone/signal/GreaterThan.js
+++ b/Tone/signal/GreaterThan.js
@@ -35,7 +35,7 @@ define(["../core/Tone", "../signal/GreaterThanZero", "../signal/Subtract", "../s
 		this._gtz = this.output = new Tone.GreaterThanZero();
 
 		//connect
-		this._param.connect(this._gtz);
+		Tone.connect(this._param, this._gtz);
 		this.proxy = false;
 	};
 

--- a/Tone/signal/GreaterThanZero.js
+++ b/Tone/signal/GreaterThanZero.js
@@ -39,7 +39,7 @@ define(["../core/Tone", "../signal/Signal", "../signal/Multiply", "../signal/Wav
 		this._scale = this.input = new Tone.Multiply(10000);
 
 		//connections
-		this._scale.connect(this._thresh);
+		Tone.connect(this._scale, this._thresh);
 	};
 
 	Tone.extend(Tone.GreaterThanZero, Tone.SignalBase);

--- a/Tone/signal/Modulo.js
+++ b/Tone/signal/Modulo.js
@@ -50,9 +50,9 @@ define(["../core/Tone", "../signal/WaveShaper", "../signal/Multiply", "../signal
 
 		//connections
 		this.input.fan(this._shaper, this._subtract);
-		this._modSignal.connect(this._multiply, 0, 0);
-		this._shaper.connect(this._multiply, 0, 1);
-		this._multiply.connect(this._subtract, 0, 1);
+		Tone.connect(this._modSignal, this._multiply, 0, 0);
+		Tone.connect(this._shaper, this._multiply, 0, 1);
+		Tone.connect(this._multiply, this._subtract, 0, 1);
 		this._setWaveShaper(modulus);
 	};
 

--- a/Tone/signal/Normalize.js
+++ b/Tone/signal/Normalize.js
@@ -46,7 +46,7 @@ define(["../core/Tone", "../signal/Add", "../signal/Multiply"], function(Tone){
 		 */
 		this._div = this.output = new Tone.Multiply(1);
 
-		this._sub.connect(this._div);
+		Tone.connect(this._sub, this._div);
 		this._setRange();
 	};
 

--- a/Tone/signal/ScaleExp.js
+++ b/Tone/signal/ScaleExp.js
@@ -32,7 +32,7 @@ define(["../core/Tone", "../signal/Scale", "../signal/Pow"], function(Tone){
 		 */
 		this._exp = this.input = new Tone.Pow(Tone.defaultArg(exponent, 2));
 
-		this._exp.connect(this._scale);
+		Tone.connect(this._exp, this._scale);
 	};
 
 	Tone.extend(Tone.ScaleExp, Tone.SignalBase);

--- a/Tone/signal/Subtract.js
+++ b/Tone/signal/Subtract.js
@@ -49,7 +49,7 @@ define(["../core/Tone", "../signal/Add", "../signal/Negate", "../signal/Signal",
 		 *  @type {Tone.Signal}
 		 */
 		this._param = this.input[1] = new Tone.Signal(value);
-		this._param.chain(this._neg, this._sum);
+		Tone.chain(this._param, this._neg, this._sum);
 		this.proxy = false;
 	};
 

--- a/Tone/signal/Zero.js
+++ b/Tone/signal/Zero.js
@@ -17,7 +17,7 @@ define(["../core/Tone", "../core/Gain", "../signal/SignalBase"], function(Tone){
 		 */
 		this._gain = this.input = this.output = new Tone.Gain();
 
-		this.context.getConstant(0).connect(this._gain);
+		Tone.connect(this.context.getConstant(0), this._gain);
 	};
 
 	Tone.extend(Tone.Zero, Tone.SignalBase);

--- a/Tone/source/AMOscillator.js
+++ b/Tone/source/AMOscillator.js
@@ -78,7 +78,7 @@ define(["../core/Tone", "../source/Source", "../source/Oscillator", "../signal/M
 
 		//connections
 		Tone.chain(this.frequency, this.harmonicity, this._modulator.frequency);
-		this.detune.connect(this._modulator.detune);
+		Tone.connect(this.detune, this._modulator.detune);
 		Tone.chain(this._modulator, this._modulationScale, this._modulationNode.gain);
 		Tone.chain(this._carrier, this._modulationNode, this.output);
 

--- a/Tone/source/AMOscillator.js
+++ b/Tone/source/AMOscillator.js
@@ -77,10 +77,10 @@ define(["../core/Tone", "../source/Source", "../source/Oscillator", "../signal/M
 		this._modulationNode = new Tone.Gain(0);
 
 		//connections
-		this.frequency.chain(this.harmonicity, this._modulator.frequency);
+		Tone.chain(this.frequency, this.harmonicity, this._modulator.frequency);
 		this.detune.connect(this._modulator.detune);
-		this._modulator.chain(this._modulationScale, this._modulationNode.gain);
-		this._carrier.chain(this._modulationNode, this.output);
+		Tone.chain(this._modulator, this._modulationScale, this._modulationNode.gain);
+		Tone.chain(this._carrier, this._modulationNode, this.output);
 
 		this.phase = options.phase;
 

--- a/Tone/source/BufferSource.js
+++ b/Tone/source/BufferSource.js
@@ -63,7 +63,7 @@ define(["../core/Tone", "../core/Buffer", "../source/Source", "../core/Gain",
 		 *  @private
 		 */
 		this._source = this.context.createBufferSource();
-		this._source.connect(this._gainNode);
+		Tone.connect(this._source, this._gainNode);
 		this._source.onended = this._onended.bind(this);
 
 		/**

--- a/Tone/source/FMOscillator.js
+++ b/Tone/source/FMOscillator.js
@@ -80,13 +80,13 @@ define(["../core/Tone", "../source/Source", "../source/Oscillator",
 		this._modulationNode = new Tone.Gain(0);
 
 		//connections
-		this.frequency.connect(this._carrier.frequency);
+		Tone.connect(this.frequency, this._carrier.frequency);
 		Tone.chain(this.frequency, this.harmonicity, this._modulator.frequency);
 		Tone.chain(this.frequency, this.modulationIndex, this._modulationNode);
-		this._modulator.connect(this._modulationNode.gain);
-		this._modulationNode.connect(this._carrier.frequency);
-		this._carrier.connect(this.output);
-		this.detune.connect(this._modulator.detune);
+		Tone.connect(this._modulator, this._modulationNode.gain);
+		Tone.connect(this._modulationNode, this._carrier.frequency);
+		Tone.connect(this._carrier, this.output);
+		Tone.connect(this.detune, this._modulator.detune);
 
 		this.phase = options.phase;
 

--- a/Tone/source/FMOscillator.js
+++ b/Tone/source/FMOscillator.js
@@ -81,8 +81,8 @@ define(["../core/Tone", "../source/Source", "../source/Oscillator",
 
 		//connections
 		this.frequency.connect(this._carrier.frequency);
-		this.frequency.chain(this.harmonicity, this._modulator.frequency);
-		this.frequency.chain(this.modulationIndex, this._modulationNode);
+		Tone.chain(this.frequency, this.harmonicity, this._modulator.frequency);
+		Tone.chain(this.frequency, this.modulationIndex, this._modulationNode);
 		this._modulator.connect(this._modulationNode.gain);
 		this._modulationNode.connect(this._carrier.frequency);
 		this._carrier.connect(this.output);

--- a/Tone/source/FatOscillator.js
+++ b/Tone/source/FatOscillator.js
@@ -209,9 +209,9 @@ define(["../core/Tone", "../source/Source", "../source/Oscillator",
 					}
 					osc.phase = this._phase + (i / count) * 360;
 					osc.volume.value = -6 - count*1.1;
-					this.frequency.connect(osc.frequency);
-					this.detune.connect(osc.detune);
-					osc.connect(this.output);
+					Tone.connect(this.frequency, osc.frequency);
+					Tone.connect(this.detune, osc.detune);
+					Tone.connect(osc, this.output);
 					this._oscillators[i] = osc;
 				}
 				//set the spread

--- a/Tone/source/GrainPlayer.js
+++ b/Tone/source/GrainPlayer.js
@@ -188,7 +188,8 @@ define(["../core/Tone", "../source/Source", "../core/Buffer", "../source/BufferS
 			"loopEnd" : this._loopEnd,
 			//compute the playbackRate based on the detune
 			"playbackRate" : Tone.intervalToFrequencyRatio(this.detune / 100)
-		}).connect(this.output);
+		});
+		Tone.connect(source, this.output);
 
 		source.start(time, this._offset);
 		this._offset += this.grainSize;

--- a/Tone/source/Noise.js
+++ b/Tone/source/Noise.js
@@ -123,7 +123,7 @@ define(["../core/Tone", "../source/Source", "../core/Buffer",
 	 */
 	Tone.Noise.prototype._start = function(time){
 		var buffer = _noiseBuffers[this._type];
-		this._source = new Tone.BufferSource(buffer).connect(this.output);
+		Tone.connect(this._source = new Tone.BufferSource(buffer), this.output);
 		this._source.loop = true;
 		this._source.playbackRate.value = this._playbackRate;
 		this._source.start(this.toSeconds(time), Math.random() * (buffer.duration - 0.001));

--- a/Tone/source/OmniOscillator.js
+++ b/Tone/source/OmniOscillator.js
@@ -225,9 +225,9 @@ define(["../core/Tone", "../source/Source", "../source/Oscillator", "../source/P
 				}, this.blockTime);
 			}
 			this._oscillator = new OscillatorConstructor();
-			this.frequency.connect(this._oscillator.frequency);
-			this.detune.connect(this._oscillator.detune);
-			this._oscillator.connect(this.output);
+			Tone.connect(this.frequency, this._oscillator.frequency);
+			Tone.connect(this.detune, this._oscillator.detune);
+			Tone.connect(this._oscillator, this.output);
 			if (this.state === Tone.State.Started){
 				this._oscillator.start(now);
 			}

--- a/Tone/source/Oscillator.js
+++ b/Tone/source/Oscillator.js
@@ -130,9 +130,9 @@ function(Tone){
 			this._oscillator.type = this._type;
 		}
 		//connect the control signal to the oscillator frequency & detune
-		this._oscillator.connect(this.output);
-		this.frequency.connect(this._oscillator.frequency);
-		this.detune.connect(this._oscillator.detune);
+		Tone.connect(this._oscillator, this.output);
+		Tone.connect(this.frequency, this._oscillator.frequency);
+		Tone.connect(this.detune, this._oscillator.detune);
 		//start the oscillator
 		time = this.toSeconds(time);
 		this._oscillator.start(time);

--- a/Tone/source/OscillatorNode.js
+++ b/Tone/source/OscillatorNode.js
@@ -49,7 +49,7 @@ define(["../core/Tone", "../core/Buffer", "../source/Source", "../core/Gain",
 		 *  @private
 		 */
 		this._oscillator = this.context.createOscillator();
-		this._oscillator.connect(this._gainNode);
+		Tone.connect(this._oscillator, this._gainNode);
 		this.type = options.type;
 
 		/**

--- a/Tone/source/PWMOscillator.js
+++ b/Tone/source/PWMOscillator.js
@@ -70,7 +70,7 @@ define(["../core/Tone", "../source/Source", "../source/PulseOscillator",
 		this.modulationFrequency = this._pulse.frequency;
 
 		//connections
-		this._modulator.chain(this._scale, this._pulse.width);
+		Tone.chain(this._modulator, this._scale, this._pulse.width);
 		this._pulse.connect(this.output);
 		this._readOnly(["modulationFrequency", "frequency", "detune"]);
 	};

--- a/Tone/source/PWMOscillator.js
+++ b/Tone/source/PWMOscillator.js
@@ -71,7 +71,7 @@ define(["../core/Tone", "../source/Source", "../source/PulseOscillator",
 
 		//connections
 		Tone.chain(this._modulator, this._scale, this._pulse.width);
-		this._pulse.connect(this.output);
+		Tone.connect(this._pulse, this.output);
 		this._readOnly(["modulationFrequency", "frequency", "detune"]);
 	};
 

--- a/Tone/source/Player.js
+++ b/Tone/source/Player.js
@@ -223,7 +223,8 @@ define(["../core/Tone", "../core/Buffer", "../source/Source", "../source/TickSou
 			"playbackRate" : this._playbackRate,
 			"fadeIn" : this.fadeIn,
 			"fadeOut" : this.fadeOut,
-		}).connect(this.output);
+		});
+		Tone.connect(source, this.output);
 
 		//set the looping properties
 		if (!this._loop && !this._synced){

--- a/Tone/source/Players.js
+++ b/Tone/source/Players.js
@@ -236,7 +236,8 @@ define(["../core/Tone", "../source/Player", "../component/Volume", "../core/Audi
 	 *                                 when the url is loaded.
 	 */
 	Tone.Players.prototype.add = function(name, url, callback){
-		this._players[name] = new Tone.Player(url, callback).connect(this.output);
+		this._players[name] = new Tone.Player(url, callback);
+		Tone.connect(this._players[name], this.output);
 		this._players[name].fadeIn = this._fadeIn;
 		this._players[name].fadeOut = this._fadeOut;
 		return this;

--- a/Tone/source/PulseOscillator.js
+++ b/Tone/source/PulseOscillator.js
@@ -76,8 +76,8 @@ define(["../core/Tone", "../source/Source", "../source/Oscillator",
 		});
 
 		//connections
-		this._sawtooth.chain(this._thresh, this.output);
-		this.width.chain(this._widthGate, this._thresh);
+		Tone.chain(this._sawtooth, this._thresh, this.output);
+		Tone.chain(this.width, this._widthGate, this._thresh);
 		this._readOnly(["width", "frequency", "detune"]);
 	};
 

--- a/Tone/source/UserMedia.js
+++ b/Tone/source/UserMedia.js
@@ -123,7 +123,7 @@ define(["../core/Tone", "../component/Volume", "../core/AudioNode"], function(To
 					//Wrap a MediaStreamSourceNode around the live input stream.
 					this._mediaStream = this.context.createMediaStreamSource(stream);
 					//Connect the MediaStreamSourceNode to a gate gain node
-					this._mediaStream.connect(this.output);
+					Tone.connect(this._mediaStream, this.output);
 				}
 				return this;
 			}.bind(this));

--- a/examples/funkyShape.html
+++ b/examples/funkyShape.html
@@ -211,7 +211,7 @@
 		    "Q": 8
 		});
 
-		var bass = new Tone.PulseOscillator("A2", 0.4).chain(bassFilter, bassEnvelope);
+		var bass = Tone.chain(new Tone.PulseOscillator("A2", 0.4), bassFilter, bassEnvelope);
 		bass.start();
 
 		var bassPart = new Tone.Part(function(time, note){

--- a/examples/mixer.html
+++ b/examples/mixer.html
@@ -86,7 +86,7 @@
 			player.loop = true;
 			var soloCtrl = new Tone.Solo();
 			var panVol = new Tone.PanVol();
-			player.chain(panVol, soloCtrl, Tone.Master);
+			Tone.chain(player, panVol, soloCtrl, Tone.Master);
 
 			var container = $("<div>", {
 				"class" : "Group"

--- a/examples/pianoPhase.html
+++ b/examples/pianoPhase.html
@@ -62,7 +62,7 @@
 			"wet" : 0.3
 		});
 
-		merge.chain(reverb, Tone.Master);
+		Tone.chain(merge, reverb, Tone.Master);
 
 		//the synth settings
 		var synthSettings = {

--- a/examples/shiny.html
+++ b/examples/shiny.html
@@ -48,12 +48,12 @@
 		});
 
 		//hats
-		var hats = new Tone.Player({
+		var hats = Tone.chain(new Tone.Player({
 			"url" : "./audio/505/hh.[mp3|ogg]",
 			"volume" : -10,
 			"retrigger" : true,
 			"fadeOut" : 0.05
-		}).chain(distortion, drumCompress);
+		}), distortion, drumCompress);
 
 		var hatsLoop = new Tone.Loop({
 			"callback" : function(time){
@@ -64,11 +64,11 @@
 		}).start("1m");
 
 		//SNARE PART
-		var snare = new Tone.Player({
+		var snare = Tone.chain(new Tone.Player({
 			"url" : "./audio/505/snare.[mp3|ogg]", 
 			"retrigger" : true,
 			"fadeOut" : 0.1
-		}).chain(distortion, drumCompress);
+		}), distortion, drumCompress);
 
 		var snarePart = new Tone.Sequence(function(time, velocity){
 			snare.volume.value = Tone.gainToDb(velocity);

--- a/examples/signal.html
+++ b/examples/signal.html
@@ -74,13 +74,13 @@
 		var mult = new Tone.Multiply(2.5);
 		
 		//chain the components together
-		frequency.chain(scale, mult);
+		Tone.chain(frequency, scale, mult);
 		scale.connect(rightOsc.frequency);
 		mult.connect(leftOsc.frequency);
 
 		//multiply the frequency by 2 to get the octave above
 		var detuneScale = new Tone.Scale(14, 4);
-		frequency.chain(detuneScale, detuneLFO.frequency);		
+		Tone.chain(frequency, detuneScale, detuneLFO.frequency);
 
 		// GUI //
 

--- a/test/component/Meter.js
+++ b/test/component/Meter.js
@@ -42,7 +42,7 @@ function(Meter, Basic, Offline, Test, Signal, PassAudio, Tone, Merge, Oscillator
 				var meter;
 				return PassAudio(function(input){
 					meter = new Meter();
-					input.chain(meter, Tone.Master);
+					Tone.chain(input, meter, Tone.Master);
 				});
 			});
 			

--- a/test/core/AudioNode.js
+++ b/test/core/AudioNode.js
@@ -176,7 +176,7 @@ function(Test, Tone, AudioNode, PassAudio, Gain, Oscillator, Merge,
 				return PassAudio(function(input){
 					var node0 = new Gain();
 					var node1 = new Gain().toMaster();
-					input.chain(node0, node1);
+					Tone.chain(input, node0, node1);
 				});
 			});
 

--- a/test/helper/Test.js
+++ b/test/helper/Test.js
@@ -69,7 +69,7 @@ define(["Tone/core/Tone", "chai", "Tone/core/Context", "Tone/core/Transport", "T
 		};
 
 		Test.connect = function(node, inputNumber){
-			this.input.connect(node, 0, inputNumber);
+			Tone.connect(this.input, node, 0, inputNumber);
 			this.input.disconnect();
 		};
 


### PR DESCRIPTION
Hi @tambien, I hope you're doing good.

this is not meant to be a mergeable pull request. It is more like a proof of concept which could be extended to other parts of Tone.js if you like it.

I recently noticed that Tone.js doesn't work well with my [standardized-audio-context](https://github.com/chrisguttandin/standardized-audio-context) package. After some debugging I figured that Tone.js is modifiying built-in objects like the AudioContext prototype. My library on the other hand uses these objects to determine the API support in the currently used browser.

Therefore I began to replace every modification of built-in objects with internal helper functions. For now I only replaced the chain() and connect() functions of AudioNodes.

I would argue that every modification of a built-in object should ideally be replaced with a helper function as it is not considered a good practice to modify objects owned by the browser. Tone.js is so popular that it might one day cause a similar problem as MooTools did by modifying the Array.prototype. (https://esdiscuss.org/topic/having-a-non-enumerable-array-prototype-contains-may-not-be-web-compatible)

Do you although think that using internal helpers is a viable approach? I'm curious on your thoughts.