### PR TITLE
Should OfflineContext be available for the entire duration of an async callback?

### DIFF
--- a/test/core/Offline.js
+++ b/test/core/Offline.js
@@ -1,5 +1,7 @@
 import Test from "helper/Test";
 import Offline from "Tone/core/Offline";
+import Context from "Tone/core/Context";
+import OfflineContext from "Tone/core/OfflineContext";
 import Transport from "Tone/core/Transport";
 import Oscillator from "Tone/source/Oscillator";
 import Tone from "Tone/core/Tone";
@@ -43,6 +45,26 @@ describe("Offline", function(){
 			BufferTest(buffer);
 			expect(buffer.isSilent()).to.be.false;
 		});
+	});
+
+	it("overrides Tone.context with OfflineContext during the callback", function(){
+		return Offline(function(){
+			expect(Tone.context).to.be.an.instanceof(OfflineContext);
+		}, 0.01);
+	});
+
+	it("does not restore Tone.context during asynchronous calls", function(){
+		return Offline(function(){
+			return Promise.resolve().then(function () {
+				expect(Tone.context).to.be.an.instanceof(OfflineContext);
+			});
+		}, 0.01);
+	});
+
+	it("restores Tone.context immediately", function(){
+		var promise = Offline(function(){}, 0.01);
+		expect(Tone.context).to.be.an.instanceof(Context);
+		return promise;
 	});
 
 	it("returning a promise defers the rendering till the promise resolves", function(){


### PR DESCRIPTION
The problem is, the second test case I added ("does not restore Tone.context during asynchronous calls") is failing.

The other problem is, it's not easy to fix, the easy attempt will break the third test case I added ("restores Tone.context immediately").

Use case: `fetch` media files for offline rendering and use `Tone.context.decodeAudioData` to decode them.

I understand there are various workarounds (fetch *before* the `Tone.Offline` call, pass down a reference to the `OfflineContext` instance, etc.) but my first attempt wrongly assuming `Tone.context` is an `OfflineContext` even in async calls ended up in cryptic exceptions (esp. in Firefox) and quite a bit of headscratching.

Possible solutions I see:
- Breaking API change to not modify `Tone.context` at all and expose it as a callback argument
- A warning logged when attempting what I did in "does not restore Tone.context during asynchronous calls" test case
- A warning in the documentation and suggested workaround

@tambien What do you think?