### PR TITLE
README for examples directory

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@ If you're looking for ideas for where to get started, consider jumping in on any
 
 ### Examples
 
-To contribute examples, please follow the current style of the examples. Add your example's title and file name to `ExampleList.js` file for it to appear in the examples list on the index page. 
+To contribute examples, please follow the current style of the examples. Add your example's title and file name to `examples/js/ExampleList.json` for it to appear in the examples list on the index page.
 
 ### Docs
 
@@ -32,4 +32,4 @@ You can also take a look at Tone.js' [code coverage](https://coveralls.io/github
 
 ### Synths/Effects
 
-If you'd like to contribute a cool and expressive synth or effect, i'd love to hear it. Please send me an example that i can play with along with the PR. 
+If you'd like to contribute a cool and expressive synth or effect, i'd love to hear it. Please send me an example that i can play with along with the PR.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,23 @@
+These examples use web components (e.g. `<tone-example>`) which are defined in the [Tonejs/ui](https://github.com/Tonejs/ui) repository.
+
+### Running examples locally
+
+Check out the repository, and from the root run:
+
+```
+$ npm install
+...
+$ npm run build
+```
+
+Once this is done, you can start a local server with Python:
+
+```
+$ python -m SimpleHTTPServer 8000
+```
+
+Then, from a browser visit http://localhost:8000/examples. (See also: [installation instructions on the wiki](https://github.com/Tonejs/Tone.js/wiki/Installation#newbie-macos-quickstart-to-get-examples-running))
+
+### Adding examples
+
+To contribute examples, please follow the current style of the examples. Add your example's title and file name to `js/ExampleList.json` file for it to appear in the examples list on the index page. (cf. [CONTRIBUTING.md](https://github.com/Tonejs/Tone.js/blob/dev/.github/CONTRIBUTING.md))


### PR DESCRIPTION
It took me a fairly long time to figure out what was going on with the web components used in the examples. I tried grepping for the component names like `tone-example`, `tone-fft`, but that just told me they were defined in some blob of minified js at `examples/js/tonejs-ui.js`. Hopefully this clarifies for future readers.