### PR TITLE
Changed how some Defaults functions work so class and option types ha…

### DIFF
--- a/Tone/component/analysis/Analyser.test.ts
+++ b/Tone/component/analysis/Analyser.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { BasicTests } from "test/helper/Basic";
 import { Noise } from "../../source/Noise";
-import { Analyser } from "./Analyser";
+import { Analyser, AnalyserOptions } from "./Analyser";
 
 describe("Analyser", () => {
 
@@ -13,7 +13,7 @@ describe("Analyser", () => {
 			size: 32,
 			smoothing: 0.2,
 		});
-		const values = anl.get();
+		const values = anl.get<Analyser, AnalyserOptions>();
 		expect(values.size).to.equal(32);
 		expect(values.smoothing).to.equal(0.2);
 		anl.dispose();

--- a/Tone/component/analysis/Analyser.ts
+++ b/Tone/component/analysis/Analyser.ts
@@ -4,7 +4,7 @@ import { optionsFromArguments } from "../../core/util/Defaults";
 
 type AnalyserType = "fft" | "waveform";
 
-interface AnalyserOptions extends ToneAudioNodeOptions {
+export interface AnalyserOptions extends ToneAudioNodeOptions {
 	size: PowerOfTwo;
 	type: AnalyserType;
 	smoothing: NormalRange;

--- a/Tone/core/context/ToneWithContext.ts
+++ b/Tone/core/context/ToneWithContext.ts
@@ -109,8 +109,8 @@ export abstract class ToneWithContext<Options extends ToneWithContextOptions> ex
 	 * osc.get();
 	 * //returns {"type" : "sine", "frequency" : 440, ...etc}
 	 */
-	get(): Options {
-		const defaults = getDefaultsFromInstance(this) as Options;
+	get<ClassType, ClassOptionsType>(): ClassOptionsType {
+		const defaults = getDefaultsFromInstance<ClassType, ClassOptionsType>(this);
 		Object.keys(defaults).forEach(attribute => {
 			if (Reflect.has(this, attribute)) {
 				const member = this[attribute];
@@ -146,7 +146,7 @@ export abstract class ToneWithContext<Options extends ToneWithContextOptions> ex
 	 * 	"type" : "highpass"
 	 * });
 	 */
-	set(props: RecursivePartial<Options>): this {
+	set<ClassOptionsType>(props: RecursivePartial<ClassOptionsType>): this {
 		Object.keys(props).forEach(attribute => {
 			if (Reflect.has(this, attribute) && isDefined(this[attribute])) {
 				if (this[attribute] && isDefined(this[attribute].value) && isDefined(this[attribute].setValueAtTime)) {

--- a/Tone/core/util/Defaults.ts
+++ b/Tone/core/util/Defaults.ts
@@ -85,12 +85,11 @@ export function optionsFromArguments<T extends object>(
 /**
  * Return this instances default values by calling Constructor.getDefaults()
  */
-export function getDefaultsFromInstance<T>(instance: T): BaseToneOptions {
-	type ToneClass = {
+export function getDefaultsFromInstance<T extends {}, O extends {}>(instance: unknown): O {
+	type ToneClass =  T & {
 		constructor: ToneClass;
-		getDefaults: () => BaseToneOptions;
-	} & T;
-
+		getDefaults: () => O;
+	};
 	return (instance as ToneClass).constructor.getDefaults();
 }
 

--- a/Tone/instrument/MembraneSynth.test.ts
+++ b/Tone/instrument/MembraneSynth.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { BasicTests } from "test/helper/Basic";
 import { CompareToFile } from "test/helper/CompareToFile";
 import { InstrumentTest } from "test/helper/InstrumentTests";
-import { MembraneSynth } from "./MembraneSynth";
+import { MembraneSynth, MembraneSynthOptions } from "./MembraneSynth";
 
 describe("MembraneSynth", () => {
 
@@ -67,7 +67,7 @@ describe("MembraneSynth", () => {
 			drumSynth.set({
 				envelope : { decay: 0.24 },
 			});
-			expect(drumSynth.get().envelope.decay).to.equal(0.24);
+			expect(drumSynth.get<MembraneSynth, MembraneSynthOptions>().envelope.decay).to.equal(0.24);
 			drumSynth.dispose();
 		});
 	});

--- a/test/helper/PassAudioStereo.ts
+++ b/test/helper/PassAudioStereo.ts
@@ -1,0 +1,33 @@
+import { expect } from "chai";
+import { Merge } from "../../Tone/component/channel/Merge";
+import { Signal } from "../../Tone/signal/Signal";
+import { Offline } from "./Offline";
+
+export function PassAudioStereo(before: (merge: Merge) => void): Promise<void> {
+	const duration = 0.2;
+	return Offline(() => {
+		const merge = new Merge();
+		const sigL = new Signal<number>(0);
+		sigL.connect(merge, 0, 0);
+		const sigR = new Signal<number>(0);
+		sigR.connect(merge, 0, 1);
+		before(merge);
+		sigL.setValueAtTime(1, duration / 2);
+		sigR.setValueAtTime(1, duration / 2);
+	}, duration, 2).then(buffer => {
+		let silent = true;
+		// @ts-ignore -- seems to be an issue with @tone/plot/TestAudioBuffer::forEach callback function args definition
+		buffer.forEach((l: number, r: number, time: number) => {
+			if (time >= duration / 2 && l !== 0 && r !== 0) {
+				silent = false;
+				return;
+			} else if (time < duration / 2){
+				expect(l).to.be.closeTo(0, 0.001);
+				expect(r).to.be.closeTo(0, 0.001);
+			}
+		});
+		if (silent) {
+			throw new Error("node outputs silence");
+		}
+	});
+}


### PR DESCRIPTION
Ran into some issue while rewriting tests where calling instance.get() wasn't working as it should.
• I added some types to the `get` and `set` functions in `context/ToneWithContext`
• I added some types to `getDefaultsFromInstance` in `util/Defaults`

Then added some examples of how this would affect existing test files.

