### PR TITLE
catch errors thrown by playbackRate AudioParam in Safari

### DIFF
--- a/Tone/core/context/Param.ts
+++ b/Tone/core/context/Param.ts
@@ -115,7 +115,13 @@ export class Param<Type extends Unit = number>
 		this.input = this.context.createGain();
 		// initialize
 		this._param = options.param;
-		this.input.connect(this._param);
+		try {
+			this.input.connect(this._param);
+		} catch (err) {
+			if (err.name !== 'NotSupportedError') {
+				throw err;
+			}
+		}
 		this._events = new Timeline<AutomationEvent>(1000);
 		this._initialValue = this._param.defaultValue;
 		this.units = options.units;
@@ -480,10 +486,22 @@ export class Param<Type extends Unit = number>
 	 * onto the parameter and replace the connections.
 	 */
 	setParam(param: AudioParam): this {
-		this.input.disconnect(this._param);
+		try {
+			this.input.disconnect(this._param);
+		} catch (err) {
+			if (err.name !== 'InvalidAccessError') {
+				throw err;
+			}
+		}
 		this.apply(param);
 		this._param = param;
-		this.input.connect(this._param);
+		try {
+			this.input.connect(this._param);
+		} catch (err) {
+			if (err.name !== 'NotSupportedError') {
+				throw err;
+			}
+		}
 		return this;
 	}
 


### PR DESCRIPTION
This pull request is meant to fix the problem that the playbackRate AudioParam doesn't support connecting something to it and standardized-audio-context throws an error when connecting something to it.