### PR TITLE
Add 'randomWalk' pattern generator / add corresponding tests #622

### DIFF
--- a/Tone/event/PatternGenerator.test.ts
+++ b/Tone/event/PatternGenerator.test.ts
@@ -66,7 +66,7 @@ describe("PatternGenerator", () => {
 			expect(getArrayValues(pattern, 10)).to.deep.equal([4, 2, 3, 1, 2, 0, 1, 4, 2, 3]);
 		});
 
-		it("outputs random elements form the values", () => {
+		it("outputs random elements from the values", () => {
 			const values = [0, 1, 2, 3, 4];
 			const pattern = PatternGenerator(values, "random");
 			for (let i = 0; i < 10; i++) {
@@ -77,6 +77,17 @@ describe("PatternGenerator", () => {
 		it("does randomOnce pattern", () => {
 			const pattern = PatternGenerator([4, 5, 6, 7, 8], "randomOnce");
 			expect(getArrayValues(pattern, 10).sort()).to.deep.equal([4, 4, 5, 5, 6, 6, 7, 7, 8, 8]);
+                });
+                
+                it("randomly walks up or down 1 step without repeating", () => {
+			const values = [0, 1, 2, 3, 4];
+                        const pattern = PatternGenerator(values, "randomWalk");
+                        let currentIndex = values.indexOf(pattern.next().value);
+			for (let i = 0; i < 10; i++) {
+                                let nextIndex = values.indexOf(pattern.next().value);
+                                expect(currentIndex).to.not.equal(nextIndex);
+                                currentIndex = nextIndex;
+			}
 		});
 	});
 });

--- a/Tone/event/PatternGenerator.ts
+++ b/Tone/event/PatternGenerator.ts
@@ -4,7 +4,7 @@ import { clamp } from "../core/util/Math";
 /**
  * The name of the patterns
  */
-export type PatternName = "up" | "down" | "upDown" | "downUp" | "alternateUp" | "alternateDown" | "random" | "randomOnce";
+export type PatternName = "up" | "down" | "upDown" | "downUp" | "alternateUp" | "alternateDown" | "random" | "randomOnce" | "randomWalk";
 
 /**
  * Start at the first value and go up to the last
@@ -124,6 +124,28 @@ function* randomOnce<T>(values: T[]): IterableIterator<T> {
 }
 
 /**
+ * Randomly choose to walk up or down 1 index in the values array
+ */
+function* randomWalk<T>(values: T[]): IterableIterator<T> {
+        // randomly choose a starting index in the values array
+        let index = Math.floor(Math.random() * values.length);
+	while (true) {
+                if (index == 0) {
+                        index++; // at bottom of array, so force upward step
+                }
+                else if (index == values.length - 1) {
+                        index--; // at top of array, so force downward step
+                }
+		else if (Math.random() < 0.5) { // else choose random downward or upward step
+			index--;
+		} else {
+			index++;
+		}
+		yield values[index];
+	}
+}
+
+/**
  * PatternGenerator returns a generator which will iterate over the given array
  * of values and yield the items according to the passed in pattern
  * @param values An array of values to iterate over
@@ -149,6 +171,8 @@ export function* PatternGenerator<T>(values: T[], pattern: PatternName = "up", i
 		case "random":
 			yield* randomGen(values);
 		case "randomOnce":
-			yield* infiniteGen(values, randomOnce);
+                        yield* infiniteGen(values, randomOnce);
+                case "randomWalk":
+                        yield* randomWalk(values);
 	}
 }


### PR DESCRIPTION
See #622 
Implemented/improved 'randomWalk' as an additional choice for pattern generator.  The basic algorithm starts on a random chosen index inside the user-supplied pattern array.  It then randomly chooses whether to walk up or down 1 index in the array.  If it reaches the bottom of the array (index == 0), it is forced to walk up 1 step.  Likewise, if it reaches the top of the array (index == values.length - 1), it is forced to walk down 1 step.  This prevents the algo from getting stuck at the boundaries/edges of the array.  It will never repeat the same index (i.e. note) twice.

This pattern is desirable for users wanting to generate believable 'human-like' linear melodies because it smoothly steps between the values (i.e. note choices) much the same way as a vocalist or vocal-like instrument would randomly 'walk' through a melody or scale if asked to improvise.  

If a melodic leap is desired or needed in the randomly generated pattern, then users could alternate between 2 pattern generators:  this 'randomWalk' and 'random' (which might leap far from the current array index, or even possibly repeat the same note several times in row).  In this way, the two different pattern generators can work with each other.  For example, the currentIndex of the 'randomWalk' generator could be fed into the purely 'random' generator with a matching array list of the exact same possible note choices, and vice versa, thus producing more realistic, stylistic melodies.


