### PR TITLE
Fixing bounds in TickSource Test

### DIFF
--- a/Tone/core/clock/TickSource.test.ts
+++ b/Tone/core/clock/TickSource.test.ts
@@ -55,7 +55,7 @@ describe("TickSource", () => {
 				return time => {
 					if (time < 0.399) {
 						expect(source.ticks).to.be.closeTo(2 * time, 0.01);
-					} else if (time > 4) {
+					} else if (time > 0.4) {
 						expect(source.ticks).to.be.equal(0);
 					}
 				};


### PR DESCRIPTION
Just saw this small issue in one of the tests and thought I would make this PR! Pretty sure you meant `0.4`, right?


