### PR TITLE
Add dotted notes to the Subdivision type.

### DIFF
--- a/Tone/core/type/Units.ts
+++ b/Tone/core/type/Units.ts
@@ -46,12 +46,13 @@ export type Positive = number;
 
 /**
  * Represents a subdivision of a measure.
- * The number represents the subdivision. "t" represents a triplet.
- * e.g. "4n" is a quarter note, and "4t" is a quarter note triplet.
+ * The number represents the subdivision. "t" represents a triplet. A "." add a half.
+ * e.g. "4n" is a quarter note, "4t" is a quarter note triplet, and "4n." is a dotted quarter note.
  * @category Unit
  */
-export type Subdivision = "1m" | "1n" | "2n" | "2t" | "4n" | "4t" | "8n" | "8t" | "16n" | "16t" |
-"32n" | "32t" | "64n" | "64t" | "128n" | "128t" | "256n" | "256t" | "0";
+export type Subdivision = "1m" | "1n" | "1n." | "2n" | "2n." | "2t" | "4n" | "4n." | "4t" | "8n" | "8n." | "8t" |
+"16n" | "16n." | "16t" | "32n" | "32n." | "32t" | "64n" | "64n."| "64t" | "128n" | "128n." | "128t" |
+"256n" | "256n." | "256t" | "0";
 
 /**
  * A time object has a subdivision as the keys and a number as the values.


### PR DESCRIPTION
Reading https://github.com/Tonejs/Tone.js/blob/30e14cf7291fae180511c1ec7c998d4c752d4a52/Tone/core/type/Time.ts#L76 it looks like dotted notes can be returned, and in fact when I try it I can get a dotted note but the Typescript compiler complains that the return value cannot exist when used in a switch statement, so I think this is just an accidental omission.

1. Please make all pull requests on the `dev` branch.
2. Don't commit build files
2. Try to get all [tests](https://github.com/Tonejs/Tone.js/wiki/Testing) to pass.


