### PR TITLE
Allow the context to be resumed from an interrupted state.

### DIFF
--- a/Tone/core/context/Context.ts
+++ b/Tone/core/context/Context.ts
@@ -442,7 +442,9 @@ export class Context extends BaseContext {
 	 * to initially start the AudioContext. See [[Tone.start]]
 	 */
 	resume(): Promise<void> {
-		if (this._context.state === "suspended" && isAudioContext(this._context)) {
+		// @ts-ignore
+		if ((this._context.state === "suspended" || this._context.state === "interrupted")
+				&& isAudioContext(this._context)) {
 			return this._context.resume();
 		} else {
 			return Promise.resolve();


### PR DESCRIPTION
As is the case when running on IOS, after coming back to the page from
the home screen.

This should fix a bug on IOS, where if you go to the home screen, or if your phone goes on standby, the audiocontext state changes to interrupted.

See similar fix: 
https://github.com/goldfire/howler.js/pull/1106
and https://github.com/goldfire/howler.js/pull/928


I wasn't able to get the tests running - npm install fails with ReferenceError: Unknown plugin "transform-runtime"
Even after manually running 
`npm install babel-plugin-transform-runtime`
The trail of missing dependencies seems to keep going for a while. Not sure what's happening there. I'm also on Node 11, as the travis build file specifies.

npm build seems to run fine.


Thanks!