### PR TITLE
fix: Instrument sync

### DIFF
--- a/Tone/instrument/Instrument.ts
+++ b/Tone/instrument/Instrument.ts
@@ -80,12 +80,23 @@ export abstract class Instrument<Options extends InstrumentOptions> extends Tone
 	 * Tone.Transport.start();
 	 */
 	sync(): this {
-		if (!this._synced) {
-			this._synced = true;
+		if (this._syncState()) {
 			this._syncMethod("triggerAttack", 1);
 			this._syncMethod("triggerRelease", 0);
 		}
 		return this;
+	}
+
+	/**
+	 * set _sync
+	 */
+	protected _syncState(): boolean {
+		let changed = false;
+		if (!this._synced) {
+			this._synced = true;
+			changed = true;
+		}
+		return changed;
 	}
 
 	/**

--- a/Tone/instrument/NoiseSynth.ts
+++ b/Tone/instrument/NoiseSynth.ts
@@ -103,8 +103,10 @@ export class NoiseSynth extends Instrument<NoiseSynthOptions> {
 	}
 
 	sync(): this {
-		this._syncMethod("triggerAttack", 0);
-		this._syncMethod("triggerRelease", 0);
+		if (this._syncState()) {
+			this._syncMethod("triggerAttack", 0);
+			this._syncMethod("triggerRelease", 0);
+		}
 		return this;
 	}
 

--- a/Tone/instrument/PolySynth.ts
+++ b/Tone/instrument/PolySynth.ts
@@ -334,8 +334,10 @@ export class PolySynth<Voice extends Monophonic<any> = Synth> extends Instrument
 	}
 
 	sync(): this {
-		this._syncMethod("triggerAttack", 1);
-		this._syncMethod("triggerRelease", 1);
+		if (this._syncState()) {
+			this._syncMethod("triggerAttack", 1);
+			this._syncMethod("triggerRelease", 1);
+		}
 		return this;
 	}
 

--- a/Tone/instrument/Sampler.ts
+++ b/Tone/instrument/Sampler.ts
@@ -254,8 +254,10 @@ export class Sampler extends Instrument<SamplerOptions> {
 	}
 
 	sync(): this {
-		this._syncMethod("triggerAttack", 1);
-		this._syncMethod("triggerRelease", 1);
+		if (this._syncState()) {
+			this._syncMethod("triggerAttack", 1);
+			this._syncMethod("triggerRelease", 1);
+		}
 		return this;
 	}
 

--- a/test/helper/InstrumentTests.ts
+++ b/test/helper/InstrumentTests.ts
@@ -5,6 +5,10 @@ import { Offline } from "./Offline";
 import { OutputAudio } from "./OutputAudio";
 import { Monophonic } from "Tone/instrument/Monophonic";
 
+function wait(time) {
+	return new Promise(done => setTimeout(done, time));
+}
+
 export function InstrumentTest(Constr, note, constrArg?, optionsIndex?): void {
 
 	context("Instrument Tests", () => {
@@ -164,6 +168,35 @@ export function InstrumentTest(Constr, note, constrArg?, optionsIndex?): void {
 				transport.start(0.1);
 			}, 0.3).then((buffer) => {
 				expect(buffer.isSilent()).to.be.true;
+			});
+		});
+
+
+		it("can unsync and re-sync triggerAttack to the Transport", () => {
+			return Offline(async ({ transport }) => {
+				const instance = new Constr(constrArg);
+				instance.toDestination();
+
+				instance.sync();
+				if (note) {
+					instance.triggerAttack(note, 0.1);
+				} else {
+					instance.triggerAttack(0.1);
+				}
+				transport.start(0.1);
+				await wait(100);
+				instance.unsync();
+				transport.stop();
+
+				instance.sync();
+				if (note) {
+					instance.triggerAttack(note, 0.1);
+				} else {
+					instance.triggerAttack(0.1);
+				}
+				transport.start(0.1);
+			}, 1).then((buffer) => {
+				expect(buffer.getTimeOfFirstSound()).to.be.within(0.19, 0.25);
 			});
 		});
 


### PR DESCRIPTION
Fix some Instrument class overrides `sync` method without changing `this._sync` flag.


