### PR TITLE
docs example bugfixes, typo corrections, minor additions for clarity,…

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ To contribute examples, please follow the current style of the examples. Add you
 
 There is always more work that can be done on documentation. Especially adding good examples to methods and members to make the docs more informative and useful for people coming from diverse musical and technical backgrounds.
 
-All of the docs are written in [jsdoc](http://usejsdoc.org/)-style comments in the source code. If you catch a mistake, please send a pull request.
+All of the docs are written in [TypeDoc](https://typedoc.org/)-style comments in the source code. If you catch a mistake, please send a pull request.
 
 Along with this, it'd be great to integrate more visuals and references in the docs to help illustrate concepts.
 

--- a/Tone/component/channel/Channel.ts
+++ b/Tone/component/channel/Channel.ts
@@ -41,7 +41,9 @@ export class Channel extends ToneAudioNode<ChannelOptions> {
 	private _panVol: PanVol;
 
 	/**
-	 * The L/R panning control.
+	 * The L/R panning control. -1 = hard left, 1 = hard right.
+	 * @min -1
+	 * @max 1
 	 */
 	readonly pan: Param<"audioRange">;
 

--- a/Tone/component/channel/PanVol.ts
+++ b/Tone/component/channel/PanVol.ts
@@ -34,7 +34,9 @@ export class PanVol extends ToneAudioNode<PanVolOptions> {
 	private _panner: Panner;
 
 	/**
-	 * The L/R panning control.
+	 * The L/R panning control. -1 = hard left, 1 = hard right.
+	 * @min -1
+	 * @max 1
 	 */
 	readonly pan: Param<"audioRange">;
 

--- a/Tone/core/context/AbstractParam.ts
+++ b/Tone/core/context/AbstractParam.ts
@@ -56,7 +56,7 @@ export abstract class AbstractParam<TypeName extends UnitName> {
 	 * @example
 	 * return Tone.Offline(() => {
 	 * 	const signal = new Tone.Signal(0).toDestination();
-	 * 	// the ramp is starts from the previously scheduled value
+	 * 	// the ramp starts from the previously scheduled value
 	 * 	signal.setValueAtTime(0, 0.1);
 	 * 	signal.linearRampToValueAtTime(1, 0.4);
 	 * }, 0.5, 1);
@@ -68,10 +68,10 @@ export abstract class AbstractParam<TypeName extends UnitName> {
 	 * the previous scheduled parameter value to the given value.
 	 * @example
 	 * return Tone.Offline(() => {
-	 * 	const signal = new Tone.Signal(0).toDestination();
-	 * 	// the ramp is starts from the previously scheduled value
-	 * 	signal.setValueAtTime(0, 0.1);
-	 * 	signal.exponentialRampToValueAtTime(1, 0.4);
+	 * 	const signal = new Tone.Signal(1).toDestination();
+	 * 	// the ramp starts from the previously scheduled value, which must be positive
+	 * 	signal.setValueAtTime(1, 0.1);
+	 * 	signal.exponentialRampToValueAtTime(0, 0.4);
 	 * }, 0.5, 1);
 	 */
 	abstract exponentialRampToValueAtTime(value: UnitMap[TypeName], time: Time): this;
@@ -90,6 +90,11 @@ export abstract class AbstractParam<TypeName extends UnitName> {
 	 * const noise = new Tone.Noise().connect(delay).start().stop("+0.1");
 	 * // making the delay time shorter over time will also make the pitch rise
 	 * delay.delayTime.exponentialRampTo(0.01, 20);
+	 * @example
+	 * return Tone.Offline(() => {
+	 * 	const signal = new Tone.Signal(.1).toDestination();
+	 * 	signal.exponentialRampTo(5, 0.3, 0.1);
+	 * }, 0.5, 1);
 	 */
 	abstract exponentialRampTo(value: UnitMap[TypeName], rampTime: Time, startTime?: Time): this;
 
@@ -103,6 +108,12 @@ export abstract class AbstractParam<TypeName extends UnitName> {
 	 *                              value to ramp from it's current value
 	 * @param startTime 	When the ramp should start.
 	 * @returns {Param} this
+	 * @example
+	 * const delay = new Tone.FeedbackDelay(0.5, 0.98).toDestination();
+	 * // a short burst of noise through the feedback delay
+	 * const noise = new Tone.Noise().connect(delay).start().stop("+0.1");
+	 * // making the delay time shorter over time will also make the pitch rise
+	 * delay.delayTime.linearRampTo(0.01, 20);
 	 * @example
 	 * return Tone.Offline(() => {
 	 * 	const signal = new Tone.Signal(1).toDestination();

--- a/Tone/core/context/ToneAudioBuffers.ts
+++ b/Tone/core/context/ToneAudioBuffers.ts
@@ -27,7 +27,7 @@ interface ToneAudioBuffersOptions {
  * }, () => {
  * 	const player = new Tone.Player().toDestination();
  * 	// play one of the samples when they all load
- * 	player.buffer = pianoSamples.get("C2");
+ * 	player.buffer = pianoSamples.get("A2");
  * 	player.start();
  * });
  * @example


### PR DESCRIPTION
here's my new & improved docs edits PR. Couple of example code bugs fixed, a few minor additions where I would have liked to have seen them when I was reading the docs, few typos fixed.

Couple docs-related questions for possible future PRs:

1. I noticed that a significant amount of classes are completely omitted from the Tone 14.x docs, apparently because their source contains no `@category` definition. E.g. Limiter, Recorder, MidSideCompressor, FrequencyEnvelope just to name a few. Was this intentional or just an oversight? AFAICT these classes seem to still be perfectly operational in the latest Tone.

2. One potential future project that would be really helpful for me and I'd guess other Tone users would be, in the Index section of the docs pages for each class, to automate creating separate sections for unique properties & methods and inherited ones. I think that could really help separate out the less useful descriptions of the generic shared properties/methods from the ones unique to that class and make them easier to read through. Also some basic navigational sugar such as a 'back to top' and ensuring the left hand column jumps to the selected anchor would be nice-to-haves. If you agree, any pointer you could offer into exactly where in the build process the docs are converted from the typedoc-generated json into the html/css seen at tonejs.github.io would be helpful.