### PR TITLE
fix for #761

### DIFF
--- a/Tone/core/context/ToneAudioBuffer.ts
+++ b/Tone/core/context/ToneAudioBuffer.ts
@@ -356,7 +356,7 @@ export class ToneAudioBuffer extends Tone {
 	static async load(url: string): Promise<AudioBuffer> {
 
 		// test if the url contains multiple extensions
-		const matches = url.match(/\[(.+\|?)+\]$/);
+		const matches = url.match(/\[([^\]\[]+\|.+)\]$/);
 		if (matches) {
 			const extensions = matches[1].split("|");
 			let extension = extensions[0];


### PR DESCRIPTION
Improving url-parsing regexp to avoid hangs in edge case filepaths when loading a buffer from a file that contains brackets in its path string, fixes #761
