### PR TITLE
Add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,22 +12,24 @@ Tone.js is a Web Audio framework for creating interactive music in the browser. 
 
 # Installation
 
-To install the latest stable version.
+There are two ways to incorporate Tone.js into a proejct. First, it can be installed locally into a project using `npm`:
 
 ```bash
-npm install tone
+npm install tone      // Install the latest stable version
+npm install tone@next // Or, alternatively, use the 'next' version
 ```
 
-Or to install the 'next' version
-
-```bash
-npm install tone@next
-```
-
-To import Tone.js:
+Add Tone.js to a project using the JavaScript `import` syntax:
 
 ```js
-import * as Tone from 'tone'
+import * as Tone from 'tone';
+```
+
+Tone.js is also hosted at unpkg.com. It can be added directly within an HTML document, as long as it precedes any project scripts. [See the example here](https://github.com/Tonejs/Tone.js/blob/master/examples/simpleHtml.html) for more details.
+
+```html
+<script src="http://unpkg.com/tone"></script>
+<script src="myScript.js"></script>
 ```
 
 # Hello Tone

--- a/Tone/component/analysis/DCMeter.ts
+++ b/Tone/component/analysis/DCMeter.ts
@@ -4,9 +4,7 @@ import { MeterBase, MeterBaseOptions } from "./MeterBase";
 export type DCMeterOptions = MeterBaseOptions;
 
 /**
- * DCMeter gets the raw value of the input signal's waveform amplitude
- * at the current time and displays it as a value between 0 and 1.
- * See also {@link Meter}.
+ * DCMeter gets the raw value of the input signal at the current time. See also {@link Meter}.
  *
  * @example
  * const meter = new Tone.DCMeter();

--- a/Tone/component/analysis/DCMeter.ts
+++ b/Tone/component/analysis/DCMeter.ts
@@ -4,7 +4,9 @@ import { MeterBase, MeterBaseOptions } from "./MeterBase";
 export type DCMeterOptions = MeterBaseOptions;
 
 /**
- * DCMeter gets the raw value of the input signal at the current time.
+ * DCMeter gets the raw value of the input signal's waveform amplitude
+ * at the current time and displays it as a value between 0 and 1.
+ * See also {@link Meter}.
  *
  * @example
  * const meter = new Tone.DCMeter();

--- a/Tone/component/analysis/Meter.ts
+++ b/Tone/component/analysis/Meter.ts
@@ -14,6 +14,9 @@ export interface MeterOptions extends MeterBaseOptions {
 /**
  * Meter gets the [RMS](https://en.wikipedia.org/wiki/Root_mean_square)
  * of an input signal. It can also get the raw value of the input signal.
+ * Setting `normalRange` to `true` will covert the output to a range of
+ * 0-1. See an example using a graphical display 
+ * [here](https://tonejs.github.io/examples/meter).
  *
  * @example
  * const meter = new Tone.Meter();

--- a/Tone/component/analysis/Meter.ts
+++ b/Tone/component/analysis/Meter.ts
@@ -16,7 +16,7 @@ export interface MeterOptions extends MeterBaseOptions {
  * of an input signal. It can also get the raw value of the input signal.
  * Setting `normalRange` to `true` will covert the output to a range of
  * 0-1. See an example using a graphical display 
- * [here](https://tonejs.github.io/examples/meter).
+ * [here](https://tonejs.github.io/examples/meter). See also {@link DCMeter}.
  *
  * @example
  * const meter = new Tone.Meter();


### PR DESCRIPTION
I added some detail to the documentation based on recent discussions in the Google Groups forum. This adds the HTML usage option to the main README file and adds some description and links between the Meter and DCMeter docs.

Related: is there a way to view the docs locally before pushing? Running `nom run docs` generated the JSON file, but I don't want to make changes to `package.json` to change that.

Since this is my first time contributing, I ran tests and saw some failures, but they don't relate to this pull request so far as I can tell. If I did break the tests somehow, please let me know so that I can figure out how that works. I would like to be able to contribute more often, even if only to incorporate things into the docs.