### PR TITLE
Address an edge-case for "Interrupted" states in Safari.

### DIFF
--- a/Tone/core/context/Context.ts
+++ b/Tone/core/context/Context.ts
@@ -438,7 +438,7 @@ export class Context extends BaseContext {
 	 * to initially start the AudioContext. See [[Tone.start]]
 	 */
 	resume(): Promise<void> {
-		if (this._context.state === "suspended" && isAudioContext(this._context)) {
+		if (isAudioContext(this._context)) {
 			return this._context.resume();
 		} else {
 			return Promise.resolve();


### PR DESCRIPTION
See #767 for details.

We _could_ check for an `interrupted` state here instead, but I thought it made more sense to fix the `interrupted` edge-case by having Tone's `resume()` match the underlying `resume()` more closely. Please let me know if I'm overlooking anything here!


