### PR TITLE
Update AdvancedTypeCheck.ts

### DIFF
--- a/Tone/core/util/AdvancedTypeCheck.ts
+++ b/Tone/core/util/AdvancedTypeCheck.ts
@@ -1,6 +1,7 @@
 import {
-	isAnyAudioContext, isAnyAudioNode,
-	isAnyAudioParam, isAnyOfflineAudioContext,
+	AudioBuffer, isAnyAudioContext,
+	isAnyAudioNode, isAnyAudioParam,
+	isAnyOfflineAudioContext
 } from "standardized-audio-context";
 
 /**


### PR DESCRIPTION
fix https://github.com/Tonejs/Tone.js/issues/788

It was 'working" before my update because there is another classe AudioBuffer define in a file of the typescript lib d.ts who do something else, and don't need import to be used ( because it's "inside" typescript)

1. Please make all pull requests on the `dev` branch.
2. Don't commit build files
2. Try to get all [tests](https://github.com/Tonejs/Tone.js/wiki/Testing) to pass.


