### PR TITLE
Add buttons to the issue reproduction templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,8 @@
 Bugs and feature requests only please. For help questions, check out the [forum](https://groups.google.com/forum/#!forum/tonejs).
 
-**Note**: Browsers' [Autoplay Policy](https://github.com/Tonejs/Tone.js/wiki/Autoplay) leads to a lot of subtle and inconsistent bugs where Tone.js produces no sound. Check out the link for more information and the solution. 
+**Note**: Browsers' [Autoplay Policy](https://github.com/Tonejs/Tone.js/wiki/Autoplay) leads to a lot of subtle and inconsistent bugs where Tone.js produces no sound. Check out the link for more information and the solution.
 
 Please include a way to reproduce your issue
 
-https://jsfiddle.net/1f60jkq4/ (tone@latest)
-https://jsfiddle.net/z9marxbt/ (tone@next)
+https://jsfiddle.net/n2kh5zus/ (tone@latest)
+https://jsfiddle.net/4tohcn08/ (tone@next)


### PR DESCRIPTION
The old jfiddle template is using outdated API, such as `toMaster`. Also, there are warnings of starting audio contexts without user interaction. I fixed these in the new issue reproduction template.