### PR TITLE
Add fanIn()

### DIFF
--- a/Tone/core/context/ToneAudioNode.test.ts
+++ b/Tone/core/context/ToneAudioNode.test.ts
@@ -219,13 +219,13 @@ describe("ToneAudioNode", () => {
 			}, false);
 		});
 
-		it("can fan in multiple nodes to a destination", async () => {
+		it("can fan in multiple nodes to a destination", () => {
 			return PassAudio(input => {
-				const input0 = new Gain();
-				const input1 = new Gain();
-				const input2 = new Gain();
-				const output = new Gain();
-				fanIn(output, input0, input1, input2);
+				const context = input.context;
+				const gain0 = context.createGain();
+				const gain1 = context.createGain();
+				const output = context.destination;
+				fanIn(gain0, gain1, input, output);
 			});
 		});
 		
@@ -332,12 +332,13 @@ describe("ToneAudioNode", () => {
 		});
 
 		it("can fan in multiple nodes to a destination", async () => {
-			const output = new Gain();
-			const input0 = new Gain();
-			const input1 = new Gain();
-			const input2 = new Gain();
-			fanIn(output, input0, input1, input2);
-			expect(output.numberOfInputs).to.equal(3);
+			await Offline(() => {
+				const output = new Gain();
+				const input0 = new Gain();
+				const input1 = new Gain();
+				const input2 = new Gain();
+				fanIn(input0, input1, input2, output);
+			});
 		});
 	});
 

--- a/Tone/core/context/ToneAudioNode.test.ts
+++ b/Tone/core/context/ToneAudioNode.test.ts
@@ -3,7 +3,7 @@ import { Merge } from "Tone/component";
 import { Split } from "Tone/component/channel/Split";
 import { Oscillator } from "Tone/source";
 import { Gain } from "./Gain";
-import { connect, disconnect } from "./ToneAudioNode";
+import { connect, disconnect, fanIn } from "./ToneAudioNode";
 import { PassAudio } from "test/helper/PassAudio";
 import { Offline } from "test/helper/Offline";
 
@@ -218,6 +218,16 @@ describe("ToneAudioNode", () => {
 				disconnect(input);
 			}, false);
 		});
+
+		it("can fan in multiple nodes to a destination", async () => {
+			return PassAudio(input => {
+				const input0 = new Gain();
+				const input1 = new Gain();
+				const input2 = new Gain();
+				const output = new Gain();
+				fanIn(output, input0, input1, input2);
+			});
+		});
 		
 		it("can connect one channel to another", () => {
 			return PassAudio(input => {
@@ -319,6 +329,15 @@ describe("ToneAudioNode", () => {
 				connect(gain, output);
 				disconnect(gain, output);
 			});
+		});
+
+		it("can fan in multiple nodes to a destination", async () => {
+			const output = new Gain();
+			const input0 = new Gain();
+			const input1 = new Gain();
+			const input2 = new Gain();
+			fanIn(output, input0, input1, input2);
+			expect(output.numberOfInputs).to.equal(3);
 		});
 	});
 

--- a/Tone/core/context/ToneAudioNode.ts
+++ b/Tone/core/context/ToneAudioNode.ts
@@ -378,16 +378,19 @@ export function disconnect(
 }
 
 /**
- * Connect the output of this node to the rest of the nodes in parallel.
+ * Connect the output of one or more source nodes to a single destination node
  * @param nodes One or more source nodes followed by one destination node
  * @example
  * const player = new Tone.Player("https://tonejs.github.io/audio/drum-samples/conga-rhythm.mp3");
  * const player1 = new Tone.Player("https://tonejs.github.io/audio/drum-samples/conga-rhythm.mp3");
  * const filter = new Tone.Filter("G5").toDestination();
  * // connect nodes to a common destination
- * fanIn(filter, player, player1);
+ * fanIn(player, player1, filter);
  */
-export function fanIn(...nodes: any[]): void {
+export function fanIn(...nodes: OutputNode[]): void {
 	const dstNode = nodes.pop();
-	nodes.forEach(node => connect(node, dstNode));
+
+	if (isDefined(dstNode)) {
+		nodes.forEach(node => connect(node, dstNode));
+	}
 }

--- a/Tone/core/context/ToneAudioNode.ts
+++ b/Tone/core/context/ToneAudioNode.ts
@@ -257,7 +257,6 @@ export abstract class ToneAudioNode<Options extends ToneAudioNodeOptions = ToneA
 		return this;
 	}
 
-
 	/**
 	 * Dispose and disconnect
 	 */
@@ -379,7 +378,8 @@ export function disconnect(
 }
 
 /**
- * connect the output of this node to the rest of the nodes in parallel.
+ * Connect the output of this node to the rest of the nodes in parallel.
+ * @param nodes One or more source nodes followed by one destination node
  * @example
  * const player = new Tone.Player("https://tonejs.github.io/audio/drum-samples/conga-rhythm.mp3");
  * const player1 = new Tone.Player("https://tonejs.github.io/audio/drum-samples/conga-rhythm.mp3");
@@ -387,6 +387,7 @@ export function disconnect(
  * // connect nodes to a common destination
  * fanIn(filter, player, player1);
  */
-export function fanIn(dstNode: InputNode, ...srcNodes: OutputNode[]): void {
-	srcNodes.forEach(srcNode => connect(srcNode, dstNode));
+export function fanIn(...nodes: any[]): void {
+	const dstNode = nodes.pop();
+	nodes.forEach(node => connect(node, dstNode));
 }

--- a/Tone/core/context/ToneAudioNode.ts
+++ b/Tone/core/context/ToneAudioNode.ts
@@ -257,6 +257,7 @@ export abstract class ToneAudioNode<Options extends ToneAudioNodeOptions = ToneA
 		return this;
 	}
 
+
 	/**
 	 * Dispose and disconnect
 	 */
@@ -375,4 +376,17 @@ export function disconnect(
 	} else {
 		srcNode.disconnect();
 	}
+}
+
+/**
+ * connect the output of this node to the rest of the nodes in parallel.
+ * @example
+ * const player = new Tone.Player("https://tonejs.github.io/audio/drum-samples/conga-rhythm.mp3");
+ * const player1 = new Tone.Player("https://tonejs.github.io/audio/drum-samples/conga-rhythm.mp3");
+ * const filter = new Tone.Filter("G5").toDestination();
+ * // connect nodes to a common destination
+ * fanIn(filter, player, player1);
+ */
+export function fanIn(dstNode: InputNode, ...srcNodes: OutputNode[]): void {
+	srcNodes.forEach(srcNode => connect(srcNode, dstNode));
 }


### PR DESCRIPTION
This is a pull request for `fanIn()` as discussed in #834. `fanIn()` is essentially the inverse of `fan()`, connecting multiple input nodes to a single output node. Since, however, `fanIn()` involves multiple input nodes, it doesn't make sense to call it as a method on a single `ToneAudioNode`. I implemented it instead as a standalone function, a la `connect()`.

Feedback welcome!