### PR TITLE
PolySynth does not reschedule event if disposed

### DIFF
--- a/Tone/instrument/PolySynth.test.ts
+++ b/Tone/instrument/PolySynth.test.ts
@@ -121,6 +121,20 @@ describe("PolySynth", () => {
 			});
 		});
 
+		it("can stop all sounds scheduled to start in the future when disposed", () => {
+			return Offline(() => {
+				const polySynth = new PolySynth();
+				polySynth.set({ envelope: { release: 0.1 } });
+				polySynth.toDestination();
+				polySynth.triggerAttackRelease(["C4", "E4", "G4", "B4"], 0.2);
+				return atTime(0.1, () => {
+					polySynth.dispose();
+				});
+			}, 0.3).then((buffer) => {
+				expect(buffer.isSilent()).to.be.true;
+			});
+		});
+
 		it("can be synced to the transport", () => {
 			return Offline(({ transport }) => {
 				const polySynth = new PolySynth(Synth, {

--- a/Tone/instrument/PolySynth.ts
+++ b/Tone/instrument/PolySynth.ts
@@ -284,7 +284,7 @@ export class PolySynth<Voice extends Monophonic<any> = Synth> extends Instrument
 	 * @example
 	 * const poly = new Tone.PolySynth(Tone.AMSynth).toDestination();
 	 * poly.triggerAttack(["Ab3", "C4", "F5"]);
-	 * // trigger the release of the given notes. 
+	 * // trigger the release of the given notes.
 	 * poly.triggerRelease(["Ab3", "C4"], "+1");
 	 * poly.triggerRelease("F5", "+3");
 	 */

--- a/Tone/instrument/PolySynth.ts
+++ b/Tone/instrument/PolySynth.ts
@@ -250,7 +250,9 @@ export class PolySynth<Voice extends Monophonic<any> = Synth> extends Instrument
 		} else {
 			// schedule it to start in the future
 			this.context.setTimeout(() => {
-				this._scheduleEvent(type, notes, time, velocity);
+				if (!this.disposed) {
+					this._scheduleEvent(type, notes, time, velocity);
+				}
 			}, time - this.now());
 		}
 	}


### PR DESCRIPTION
I was trying to dispose of PolySynth instances during playback and had the `Synth was already disposed` assertion in `PolySynth._scheduleEvent` continually fail.

It turns out that `PolySynth._scheduleEvent` uses `setTimeout` to re-run `_scheduleEvent` if a note is occurring in the future, but that timeout does not account for the fact that the synth may be disposed in the meantime. So `_scheduleEvent` can be called again with `disposed === true`, and the assertion fails.

This PR simply checks `this.disposed` within the timeout to avoid the problem. I also added a test that fails without this new check.

This also seems to be the cause of issue #857.