### PR TITLE
GH-894: Correct 'Karplus-String' typo (fixes #894).

### DIFF
--- a/Tone/instrument/PluckSynth.ts
+++ b/Tone/instrument/PluckSynth.ts
@@ -14,7 +14,7 @@ export interface PluckSynthOptions extends InstrumentOptions {
 }
 
 /**
- * Karplus-String string synthesis.
+ * Karplus-Strong string synthesis.
  * @example
  * const plucky = new Tone.PluckSynth().toDestination();
  * plucky.triggerAttack("C4", "+0.5");


### PR DESCRIPTION
Single word pull to fix typo in PluckedSynth docs.

