### PR TITLE
Fix: Loading samples with special characters in the file name

### DIFF
--- a/Tone/core/context/ToneAudioBuffer.ts
+++ b/Tone/core/context/ToneAudioBuffer.ts
@@ -372,7 +372,7 @@ export class ToneAudioBuffer extends Tone {
 
 		// make sure there is a slash between the baseUrl and the url
 		const baseUrl = ToneAudioBuffer.baseUrl === "" || ToneAudioBuffer.baseUrl.endsWith("/") ? ToneAudioBuffer.baseUrl : ToneAudioBuffer.baseUrl + "/";
-		const response = await fetch(baseUrl + url);
+		const response = await fetch((baseUrl + url).split("/").map(encodeURIComponent).join("/"));
 		if (!response.ok) {
 			throw new Error(`could not load url: ${url}`);
 		}


### PR DESCRIPTION
This PR enables loading samples with file names like `"C#5.wav"`. 

Currently, this throws an error because special characters like `"#"` need to be encoded in the right format before being passed into `fetch()` as the URL.

The solution is to use [`encodeURIComponent()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) to convert these characters into their UTF-8 encoded escape sequences (eg. `"#"` -> `"%23"`). This is done for each level of the file path to also encode any special characters that may be present in the folder names.