### PR TITLE
Fix browser entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "tone",
 	"version": "14.8.0",
 	"description": "A Web Audio framework for making interactive music in the browser.",
-	"main": "build/Tone.js",
+	"browser": "build/Tone.js",
 	"module": "build/esm/index.js",
 	"type": "module",
 	"types": "build/esm/index.d.ts",


### PR DESCRIPTION
UMD builds should be listed in `browser`. `main` is traditionally meant for the server-side entry point (i.e. CJS)

https://docs.npmjs.com/cli/v7/configuring-npm/package-json#main
https://docs.npmjs.com/cli/v7/configuring-npm/package-json#browser

The library currently won't load in Vite / SvelteKit because of this