### PR TITLE
allow PolySynth voice constructors to extend Monophonic

### DIFF
--- a/Tone/instrument/PolySynth.ts
+++ b/Tone/instrument/PolySynth.ts
@@ -26,7 +26,8 @@ type VoiceOptions<T> =
 				T extends MonoSynth ? MonoSynthOptions :
 					T extends AMSynth ? AMSynthOptions :
 						T extends Synth ? SynthOptions :
-							never;
+							T extends Monophonic<infer U> ? U :
+								never;
 
 /**
  * The settable synth options. excludes monophonic options.


### PR DESCRIPTION
This PR allows PolySynth to support instruments built from scratch by extending Monophonic, by inferring the Options type used by the instrument. This is safe since we know this must extend `MonophonicOptions`.

```ts
// in VoiceOptions<T>
/* ... */ T extends Monophonic<infer U> ? U : /* ... */
```

I cannot verify whether this is passing tests - likely because the testing suite Tone.JS uses has some issues on M1 Macs - so testing would be very much appreciated! ❤️ 