### PR TITLE
Analyser constructor smoothing option bugfix

### DIFF
--- a/Tone/component/analysis/Analyser.ts
+++ b/Tone/component/analysis/Analyser.ts
@@ -79,6 +79,7 @@ export class Analyser extends ToneAudioNode<AnalyserOptions> {
 		// set the values initially
 		this.size = options.size;
 		this.type = options.type;
+		this.smoothing = options.smoothing;
 	}
 
 	static getDefaults(): AnalyserOptions {


### PR DESCRIPTION
Fix for the following bug: `smoothing` setting in the `Analyser` constructor is ignored (`smoothing` always ends up with the default value 0.8). Fixed by explicitly calling the `smoothingTimeConstant` setter in the constructor.
