### PR TITLE
fix for AudioBufferSourceNode stop time miscalculation

### DIFF
--- a/Tone/source/OneShotSource.ts
+++ b/Tone/source/OneShotSource.ts
@@ -168,7 +168,8 @@ export abstract class OneShotSource<
 
 		// schedule the stop callback
 		this._stopTime = this.toSeconds(time) + fadeOutTime;
-		this._stopTime = Math.max(this._stopTime, this.context.currentTime);
+		const nowTime = this.now();
+		this._stopTime = Math.max(this._stopTime, nowTime);
 		if (fadeOutTime > 0) {
 			// start the fade out curve at the given time
 			if (this._curve === "linear") {
@@ -188,7 +189,7 @@ export abstract class OneShotSource<
 				this._curve === "exponential" ? fadeOutTime * 2 : 0;
 			this._stopSource(this.now() + additionalTail);
 			this._onended();
-		}, this._stopTime - this.context.currentTime);
+		}, this._stopTime - nowTime);
 		return this;
 	}
 


### PR DESCRIPTION
Fixes #912 by using `now()` in place of `currentTime` when calculating the stop time for an audio buffer player, to allow for edge cases with `lookAhead` and end offsets set.
