### PR TITLE
fix attempt #2 for AudioBufferSourceNode stop time miscalculation, with updated tests

### DIFF
--- a/Tone/signal/ToneConstantSource.test.ts
+++ b/Tone/signal/ToneConstantSource.test.ts
@@ -152,7 +152,7 @@ describe("ToneConstantSource", () => {
 				expect(source.getStateAtTime(0)).to.equal("stopped");
 				expect(source.getStateAtTime(currentTime)).to.equal("started");
 				setTimeout(() => {
-					currentTime = source.context.currentTime;
+					currentTime = source.now();
 					source.stop(0);
 					expect(source.getStateAtTime(currentTime + 0.01)).to.equal("stopped");
 					source.dispose();

--- a/Tone/source/OneShotSource.ts
+++ b/Tone/source/OneShotSource.ts
@@ -168,7 +168,8 @@ export abstract class OneShotSource<
 
 		// schedule the stop callback
 		this._stopTime = this.toSeconds(time) + fadeOutTime;
-		this._stopTime = Math.max(this._stopTime, this.context.currentTime);
+		const nowTime = this.now();
+		this._stopTime = Math.max(this._stopTime, nowTime);
 		if (fadeOutTime > 0) {
 			// start the fade out curve at the given time
 			if (this._curve === "linear") {
@@ -188,7 +189,7 @@ export abstract class OneShotSource<
 				this._curve === "exponential" ? fadeOutTime * 2 : 0;
 			this._stopSource(this.now() + additionalTail);
 			this._onended();
-		}, this._stopTime - this.context.currentTime);
+		}, this._stopTime - nowTime);
 		return this;
 	}
 

--- a/Tone/source/OneShotSource.ts
+++ b/Tone/source/OneShotSource.ts
@@ -168,8 +168,7 @@ export abstract class OneShotSource<
 
 		// schedule the stop callback
 		this._stopTime = this.toSeconds(time) + fadeOutTime;
-		const nowTime = this.now();
-		this._stopTime = Math.max(this._stopTime, nowTime);
+		this._stopTime = Math.max(this._stopTime, this.now());
 		if (fadeOutTime > 0) {
 			// start the fade out curve at the given time
 			if (this._curve === "linear") {
@@ -189,7 +188,7 @@ export abstract class OneShotSource<
 				this._curve === "exponential" ? fadeOutTime * 2 : 0;
 			this._stopSource(this.now() + additionalTail);
 			this._onended();
-		}, this._stopTime - nowTime);
+		}, this._stopTime - this.context.currentTime);
 		return this;
 	}
 

--- a/Tone/source/buffer/Player.ts
+++ b/Tone/source/buffer/Player.ts
@@ -261,7 +261,7 @@ export class Player extends Source<PlayerOptions> {
 	}
 
 	protected _restart(time?: Seconds, offset?: Time, duration?: Time): void {
-		this._stop(time);
+		[...this._activeSources].pop()?.stop(time); // explicitly stop only the most recently created source, to avoid edge case when > 1 source exists and _stop() erroneously sets all stop times past original end offset
 		this._start(time, offset, duration);
 	}
 

--- a/Tone/source/oscillator/ToneOscillatorNode.test.ts
+++ b/Tone/source/oscillator/ToneOscillatorNode.test.ts
@@ -191,7 +191,7 @@ describe("ToneOscillatorNode", () => {
 				expect(osc.getStateAtTime(0)).to.equal("stopped");
 				expect(osc.getStateAtTime(currentTime)).to.equal("started");
 				setTimeout(() => {
-					currentTime = osc.context.currentTime;
+					currentTime = osc.now();
 					osc.stop(0);
 					expect(osc.getStateAtTime(currentTime + 0.01)).to.equal("stopped");
 					osc.dispose();


### PR DESCRIPTION
2nd try at a fix for #912, with tests updated to use the corrected time reference. All tests now pass on Mac (though not on Windows but that's a separate can of worms that has nothing to do with the changes made in this pr, see comments at #942).

I still plan to come up with a test to repro the conditions that lead to #912, will commit that when I get a chance.