### PR TITLE
avoid double-encoding file:/// urls

### DIFF
--- a/Tone/core/context/ToneAudioBuffer.ts
+++ b/Tone/core/context/ToneAudioBuffer.ts
@@ -374,7 +374,7 @@ export class ToneAudioBuffer extends Tone {
 		const baseUrl = ToneAudioBuffer.baseUrl === "" || ToneAudioBuffer.baseUrl.endsWith("/") ? ToneAudioBuffer.baseUrl : ToneAudioBuffer.baseUrl + "/";		
 		let href = baseUrl + url;
 		
-		if (!href.startsWith("file:/")) { // if file:/// scheme, assume already URL encoded
+		if ( !href.startsWith("file:/") && (decodeURIComponent(href) === href) ) { // if file:/ scheme, assume already encoded, otherwise use decodeURIComponent to check if already encoded
 			// encode special characters in file path
 			const location = document.createElement("a");
 			location.href = href;

--- a/Tone/core/context/ToneAudioBuffer.ts
+++ b/Tone/core/context/ToneAudioBuffer.ts
@@ -378,7 +378,9 @@ export class ToneAudioBuffer extends Tone {
 			// encode special characters in file path
 			const location = document.createElement("a");
 			location.href = href;
-			location.pathname = (location.pathname + location.hash).split("/").map(encodeURIComponent).join("/");
+			if (!location.href.startsWith("file:/")) { // catch local file:/ relative path, that's already encoded
+				location.pathname = (location.pathname + location.hash).split("/").map(encodeURIComponent).join("/");
+			}
 			href = location.href;
 		}
 

--- a/Tone/core/context/ToneAudioBuffer.ts
+++ b/Tone/core/context/ToneAudioBuffer.ts
@@ -371,14 +371,18 @@ export class ToneAudioBuffer extends Tone {
 		}
 
 		// make sure there is a slash between the baseUrl and the url
-		const baseUrl = ToneAudioBuffer.baseUrl === "" || ToneAudioBuffer.baseUrl.endsWith("/") ? ToneAudioBuffer.baseUrl : ToneAudioBuffer.baseUrl + "/";
+		const baseUrl = ToneAudioBuffer.baseUrl === "" || ToneAudioBuffer.baseUrl.endsWith("/") ? ToneAudioBuffer.baseUrl : ToneAudioBuffer.baseUrl + "/";		
+		let href = baseUrl + url;
 		
-		// encode special characters in file path
-		const location = document.createElement("a");
-		location.href = (baseUrl + url);
-		location.pathname = (location.pathname + location.hash).split("/").map(encodeURIComponent).join("/");
+		if (!href.startsWith("file:/")) { // if file:/// scheme, assume already URL encoded
+			// encode special characters in file path
+			const location = document.createElement("a");
+			location.href = href;
+			location.pathname = (location.pathname + location.hash).split("/").map(encodeURIComponent).join("/");
+			href = location.href;
+		}
 
-		const response = await fetch(location.href);
+		const response = await fetch(href);
 		if (!response.ok) {
 			throw new Error(`could not load url: ${url}`);
 		}

--- a/Tone/core/context/ToneAudioBuffer.ts
+++ b/Tone/core/context/ToneAudioBuffer.ts
@@ -376,12 +376,13 @@ export class ToneAudioBuffer extends Tone {
 		
 		if ( !href.startsWith("file:/") && (decodeURIComponent(href) === href) ) { // if file:/ scheme, assume already encoded, otherwise use decodeURIComponent to check if already encoded
 			// encode special characters in file path
-			const location = document.createElement("a");
-			location.href = href;
-			if (!location.href.startsWith("file:/")) { // catch local file:/ relative path, that's already encoded
-				location.pathname = (location.pathname + location.hash).split("/").map(encodeURIComponent).join("/");
+			const anchorElement = document.createElement("a");
+			anchorElement.href = href;
+			// check if already encoded one more time since in many cases setting the .href automatically encodes the string
+			if (!anchorElement.href.startsWith("file:/") && (decodeURIComponent(anchorElement.href) === anchorElement.href)) {
+				anchorElement.pathname = (anchorElement.pathname + anchorElement.hash).split("/").map(encodeURIComponent).join("/");
 			}
-			href = location.href;
+			href = anchorElement.href;
 		}
 
 		const response = await fetch(href);


### PR DESCRIPTION
#902 introduced a breaking change in that the file loader now assumes a given URL is unencoded. This is probably fine in most use cases but when loading local files using the file:/ scheme the url is already encoded.

(A more complete solution might be to add a flag somewhere so the user can specify if they know the url being passed to Tone is already encoded, to avoid double-encoding. But I figured a simple check for `startsWith("file:/")` is best for now to avoid an overly-complex solution unless it affects other users in more exotic scenarios other than just file:///.)
