### PR TITLE
Parse note strings with three sharps or flats.

### DIFF
--- a/Tone/core/type/Frequency.ts
+++ b/Tone/core/type/Frequency.ts
@@ -50,7 +50,7 @@ export class FrequencyClass<Type extends number = Hertz> extends TimeClass<Type,
 				},
 			},
 			note: {
-				regexp: /^([a-g]{1}(?:b|#|x|bb)?)(-?[0-9]+)/i,
+				regexp: /^([a-g]{1}(?:b|#|##|x|bb|###|#x|x#|bbb)?)(-?[0-9]+)/i,
 				method(pitch, octave): number {
 					const index = noteToScaleIndex[pitch.toLowerCase()];
 					const noteNumber = index + (parseInt(octave, 10) + 1) * 12;
@@ -219,13 +219,13 @@ export class FrequencyClass<Type extends number = Hertz> extends TimeClass<Type,
  * @hidden
  */
 const noteToScaleIndex = {
-	cbb: -2, cb: -1, c: 0, "c#": 1, cx: 2,
-	dbb: 0, db: 1, d: 2, "d#": 3, dx: 4,
-	ebb: 2, eb: 3, e: 4, "e#": 5, ex: 6,
-	fbb: 3, fb: 4, f: 5, "f#": 6, fx: 7,
-	gbb: 5, gb: 6, g: 7, "g#": 8, gx: 9,
-	abb: 7, ab: 8, a: 9, "a#": 10, ax: 11,
-	bbb: 9, bb: 10, b: 11, "b#": 12, bx: 13,
+	cbbb: -3, cbb: -2, cb: -1, c:  0, "c#":  1, cx:  2, "c##":  2, "c###":  3, "cx#":  3, "c#x":  3,
+	dbbb: -1, dbb:  0, db:  1, d:  2, "d#":  3, dx:  4, "d##":  4, "d###":  5, "dx#":  5, "d#x":  5,
+	ebbb:  1, ebb:  2, eb:  3, e:  4, "e#":  5, ex:  6, "e##":  6, "e###":  7, "ex#":  7, "e#x":  7,
+	fbbb:  2, fbb:  3, fb:  4, f:  5, "f#":  6, fx:  7, "f##":  7, "f###":  8, "fx#":  8, "f#x":  8,
+	gbbb:  4, gbb:  5, gb:  6, g:  7, "g#":  8, gx:  9, "g##":  9, "g###": 10, "gx#": 10, "g#x": 10,
+	abbb:  6, abb:  7, ab:  8, a:  9, "a#": 10, ax: 11, "a##": 11, "a###": 12, "ax#": 12, "a#x": 12,
+	bbbb:  8, bbb:  9, bb: 10, b: 11, "b#": 12, bx: 13, "b##": 13, "b###": 14, "bx#": 14, "b#x": 14,
 };
 
 /**


### PR DESCRIPTION
Tweaked the note string regexp and the noteToScaleIndex map, so that it can parse note strings with three sharps or flats.

Although rare, notes with three sharps or flats do occur, for example in the B# augmented seventh and Cb diminished seventh chords.


