### PR TITLE
fixes for Context options handling & micro timing bugs

### DIFF
--- a/Tone/core/context/Context.test.ts
+++ b/Tone/core/context/Context.test.ts
@@ -75,8 +75,10 @@ describe("Context", () => {
 				clockSource: "timeout",
 				latencyHint: "playback",
 				lookAhead: 0.2,
+				updateInterval: 0.1
 			});
 			expect(ctx.lookAhead).to.equal(0.2);
+			expect(ctx.updateInterval).to.equal(0.1);
 			expect(ctx.latencyHint).to.equal("playback");
 			expect(ctx.clockSource).to.equal("timeout");
 			ctx.dispose();

--- a/Tone/core/context/Context.ts
+++ b/Tone/core/context/Context.ts
@@ -420,8 +420,8 @@ export class Context extends BaseContext {
 	}
 	set lookAhead(time: Seconds) {
 		this._lookAhead = time;
-		// if lookAhead is 0, default to .025 updateInterval
-		this.updateInterval = time ? (time / 2) : .025;
+		// if lookAhead is 0, default to .0125 updateInterval
+		this.updateInterval = time ? (time / 2) : .0125;
 	}	
 	private _lookAhead!: Seconds;
 

--- a/Tone/core/context/Context.ts
+++ b/Tone/core/context/Context.ts
@@ -3,7 +3,7 @@ import { Seconds } from "../type/Units";
 import { isAudioContext } from "../util/AdvancedTypeCheck";
 import { optionsFromArguments } from "../util/Defaults";
 import { Timeline } from "../util/Timeline";
-import { isDefined, isString } from "../util/TypeCheck";
+import { isDefined } from "../util/TypeCheck";
 import {
 	AnyAudioContext,
 	createAudioContext,
@@ -38,13 +38,6 @@ export interface ContextTimeoutEvent {
  */
 export class Context extends BaseContext {
 	readonly name: string = "Context";
-
-	/**
-	 * The amount of time into the future events are scheduled. Giving Web Audio
-	 * a short amount of time into the future to schedule events can reduce clicks and
-	 * improve performance. This value can be set to 0 to get the lowest latency.
-	 */
-	lookAhead: Seconds;
 
 	/**
 	 * private reference to the BaseAudioContext
@@ -116,16 +109,20 @@ export class Context extends BaseContext {
 
 		if (options.context) {
 			this._context = options.context;
+			// custom context provided, latencyHint unknown (unless explicitly provided in options)
+			this._latencyHint = arguments[0]?.latencyHint || "";
 		} else {
 			this._context = createAudioContext({
 				latencyHint: options.latencyHint,
 			});
+			this._latencyHint = options.latencyHint;
 		}
 
 		this._ticker = new Ticker(
 			this.emit.bind(this, "tick"),
 			options.clockSource,
-			options.updateInterval
+			options.updateInterval,
+			this._context.sampleRate
 		);
 		this.on("tick", this._timeoutLoop.bind(this));
 
@@ -133,9 +130,9 @@ export class Context extends BaseContext {
 		this._context.onstatechange = () => {
 			this.emit("statechange", this.state);
 		};
-
-		this._setLatencyHint(options.latencyHint);
-		this.lookAhead = options.lookAhead;
+		
+		// if no custom updateInterval provided, updateInterval will be derived by lookAhead setter
+		this[arguments[0]?.hasOwnProperty("updateInterval") ? "_lookAhead" : "lookAhead"] = options.lookAhead;
 	}
 
 	static getDefaults(): ContextOptions {
@@ -391,8 +388,9 @@ export class Context extends BaseContext {
 	/**
 	 * How often the interval callback is invoked.
 	 * This number corresponds to how responsive the scheduling
-	 * can be. context.updateInterval + context.lookAhead gives you the
-	 * total latency between scheduling an event and hearing it.
+	 * can be. Setting to 0 will result in the lowest practial interval
+	 * based on context properties. context.updateInterval + context.lookAhead
+	 * gives you the total latency between scheduling an event and hearing it.
 	 */
 	get updateInterval(): Seconds {
 		return this._ticker.updateInterval;
@@ -411,6 +409,21 @@ export class Context extends BaseContext {
 	set clockSource(type: TickerClockSource) {
 		this._ticker.type = type;
 	}
+
+	/**
+	 * The amount of time into the future events are scheduled. Giving Web Audio
+	 * a short amount of time into the future to schedule events can reduce clicks and
+	 * improve performance. This value can be set to 0 to get the lowest latency.
+	 */
+	get lookAhead(): Seconds {
+		return this._lookAhead;
+	}
+	set lookAhead(time: Seconds) {
+		this._lookAhead = time;
+		// if lookAhead is 0, default to .025 updateInterval
+		this.updateInterval = time ? (time / 2) : .025;
+	}	
+	private _lookAhead!: Seconds;
 
 	/**
 	 * The type of playback, which affects tradeoffs between audio
@@ -432,29 +445,6 @@ export class Context extends BaseContext {
 	}
 
 	/**
-	 * Update the lookAhead and updateInterval based on the latencyHint
-	 */
-	private _setLatencyHint(hint: ContextLatencyHint | Seconds): void {
-		let lookAheadValue = 0;
-		this._latencyHint = hint;
-		if (isString(hint)) {
-			switch (hint) {
-				case "interactive":
-					lookAheadValue = 0.1;
-					break;
-				case "playback":
-					lookAheadValue = 0.5;
-					break;
-				case "balanced":
-					lookAheadValue = 0.25;
-					break;
-			}
-		}
-		this.lookAhead = lookAheadValue;
-		this.updateInterval = lookAheadValue / 2;
-	}
-
-	/**
 	 * The unwrapped AudioContext or OfflineAudioContext
 	 */
 	get rawContext(): AnyAudioContext {
@@ -469,7 +459,7 @@ export class Context extends BaseContext {
 	 * }, 100);
 	 */
 	now(): Seconds {
-		return this._context.currentTime + this.lookAhead;
+		return this._context.currentTime + this._lookAhead;
 	}
 
 	/**

--- a/Tone/core/context/Context.ts
+++ b/Tone/core/context/Context.ts
@@ -421,7 +421,7 @@ export class Context extends BaseContext {
 	set lookAhead(time: Seconds) {
 		this._lookAhead = time;
 		// if lookAhead is 0, default to .0125 updateInterval
-		this.updateInterval = time ? (time / 2) : .0125;
+		this.updateInterval = time ? (time / 2) : .01;
 	}	
 	private _lookAhead!: Seconds;
 

--- a/Tone/core/context/Context.ts
+++ b/Tone/core/context/Context.ts
@@ -414,6 +414,7 @@ export class Context extends BaseContext {
 	 * The amount of time into the future events are scheduled. Giving Web Audio
 	 * a short amount of time into the future to schedule events can reduce clicks and
 	 * improve performance. This value can be set to 0 to get the lowest latency.
+	 * Adjusting this value also affects the [[updateInterval]].
 	 */
 	get lookAhead(): Seconds {
 		return this._lookAhead;

--- a/Tone/core/context/Context.ts
+++ b/Tone/core/context/Context.ts
@@ -421,7 +421,7 @@ export class Context extends BaseContext {
 	}
 	set lookAhead(time: Seconds) {
 		this._lookAhead = time;
-		// if lookAhead is 0, default to .0125 updateInterval
+		// if lookAhead is 0, default to .01 updateInterval
 		this.updateInterval = time ? (time / 2) : .01;
 	}	
 	private _lookAhead!: Seconds;


### PR DESCRIPTION
This is mostly to fix the `Context` constructor's mishandling of `updateInterval` but also along the way fixes some other minor `Context` and `Ticker` constructor bugs, removes some unreachable/overridden/legacy code in `_setLatencyHint()`, and ensures that `updateInterval` is never unintentionally set higher than `lookAhead` which can lead to subtle timing issues. Also added a check for the expected `updateInterval` value in the `Context` constructor tests.

At first glance this probably looks like a lot of major internal plumbing refactors but it's not really! 😉  There are no breaking changes, all defaults remain as before; this is really just to address some bugs with edge cases when the user wants to roll their own `Context` using non-default values.

List of issues this addresses:

1) bugfix: `updateInterval` option in `Context` constructor is ignored:
```
console.log(new Tone.Context({updateInterval: .02}).updateInterval);
// 0.05
```

2) bugfix: `updateInterval` gets set to an unintended value in certain cases where non-default `latencyHint` or `lookAhead` are used, often greater than `lookAhead`, leading to potential subtle timing issues:
```
console.log(new Tone.Context({lookAhead: .1, latencyHint:"playback"}).updateInterval);
// 0.25
```

3) Changing `lookAhead` after context creation can lead to similar subtle timing issues because `updateInterval` doesn't automatically update along with it. Fixed by creating a `lookAhead` setter which sets the `updateInterval` to `( lookAhead / 2 )` in the spirit of the legacy `_setLatencyHint()`. When `lookAhead` is `0`, `updateInterval` defaults to `.01` which, admittedly, is just a value that I arrived at for best x-browser operation after some subjective testing on a few different devices, and can still be forced to a different value when explicitly set. See https://codepen.io/keymapper/pen/KKXKvPV in Chrome for a quick demo. It uses a short loud bass drum which results in an audible pop if the sound is clipped by the smallest amount, and uses `setInterval` rather than Tone scheduling in order to simulate a realtime source play trigger. When `lookAhead = 0` and `updateInterval` is left at the default `.05`, you'll hear a pop every 5-10 hits from the stop time getting miscalculated by a microsecond. When `updateInterval` is adjusted to `.01` the miscalculation seems *mostly* gone. (Note: due to timing/latency quirks this doesn't fix the micro-timing issue in all cases on all browsers though! I will open a separate issue for further discussion on this.).

4) bugfix: Minimum allowable `updateInterval` is miscalculated in certain cases because it is based on an assumed fixed 44100 `sampleRate`. Most non-Apple platforms seem to default to 48000, and the user can roll their own context at a wide range different rates depending on browser. Fixed by passing the context's `sampleRate` in with the `Ticker` constructor and calculating a lowest practical `_minimumUpdateInterval`. Also added the ability to pass an `updateInterval` of `0` to make it automatically set to the `_minimumUpdateInterval`.

5) bugfix: `Context.latencyHint` returns incorrect value in some cases when using a native `AudioContext`. This is mostly just an informational error, but this incorrect value was then being used by `_setLatencyHint()` to derive `updateInterval`. Since it's impossible for Tone to infer the `latencyHint` from a user-instantiated native context, I've changed `Context.latencyHint` to return an empty string when an own-rolled native context is passed in, and also set `updateInterval` to be calculated from `lookAhead` by default.
```
console.log(new Tone.Context({context: new AudioContext({latencyHint : "balanced"})}).latencyHint);
// "interactive"
```

6) Remove vestigial legacy handling of `latencyHint` in `_setLatencyHint()` much of which was unreachable code or getting overridden depending on constructor options. I think `_setLatencyHint()` was a holdover from older Tone versions where `latencyHint` in Tone had a different handling than the browser native `AudioContext.latencyHint`, perhaps from back when `latencyHint` was ignored by some browsers.