### PR TITLE
Memoize getTicksAtTime and getSecondsAtTime

### DIFF
--- a/Tone/core/clock/TickSource.test.ts
+++ b/Tone/core/clock/TickSource.test.ts
@@ -237,6 +237,35 @@ describe("TickSource", () => {
 			expect(source.getTicksAtTime(6)).to.be.closeTo(6, 0.01);
 			source.dispose();
 		});
+
+		it("will recompute memoized values when events are modified", () => {
+			const source = new TickSource(1);
+			source.start(3).pause(4);
+			expect(source.getTicksAtTime(1)).to.be.closeTo(0, 0.01);
+			expect(source.getTicksAtTime(2)).to.be.closeTo(0, 0.01);
+			expect(source.getTicksAtTime(3)).to.be.closeTo(0, 0.01);
+			expect(source.getTicksAtTime(4)).to.be.closeTo(1, 0.01);
+			expect(source.getTicksAtTime(5)).to.be.closeTo(1, 0.01);
+			source.start(1).pause(2);
+			expect(source.getTicksAtTime(1)).to.be.closeTo(0, 0.01);
+			expect(source.getTicksAtTime(2)).to.be.closeTo(1, 0.01);
+			expect(source.getTicksAtTime(3)).to.be.closeTo(1, 0.01);
+			expect(source.getTicksAtTime(4)).to.be.closeTo(2, 0.01);
+			expect(source.getTicksAtTime(5)).to.be.closeTo(2, 0.01);
+			source.setTicksAtTime(3, 1);
+			expect(source.getTicksAtTime(1)).to.be.closeTo(3, 0.01);
+			expect(source.getTicksAtTime(2)).to.be.closeTo(4, 0.01);
+			expect(source.getTicksAtTime(3)).to.be.closeTo(4, 0.01);
+			expect(source.getTicksAtTime(4)).to.be.closeTo(5, 0.01);
+			expect(source.getTicksAtTime(5)).to.be.closeTo(5, 0.01);
+			source.cancel(4);
+			expect(source.getTicksAtTime(1)).to.be.closeTo(3, 0.01);
+			expect(source.getTicksAtTime(2)).to.be.closeTo(4, 0.01);
+			expect(source.getTicksAtTime(3)).to.be.closeTo(4, 0.01);
+			expect(source.getTicksAtTime(4)).to.be.closeTo(5, 0.01);
+			expect(source.getTicksAtTime(5)).to.be.closeTo(6, 0.01);
+			source.dispose();
+		});
 	});
 
 	context("forEachTickBetween", () => {
@@ -589,6 +618,29 @@ describe("TickSource", () => {
 			expect(source.getSecondsAtTime(1)).to.be.closeTo(0, 0.01);
 			expect(source.getSecondsAtTime(1.4)).to.be.closeTo(0.4, 0.01);
 			expect(source.getSecondsAtTime(1.5)).to.be.closeTo(0, 0.01);
+			source.dispose();
+		});
+
+		it("will recompute memoized values when events are modified", () => {
+			const source = new TickSource(1);
+			source.start(3).pause(4);
+			expect(source.getSecondsAtTime(1)).to.be.closeTo(0, 0.01);
+			expect(source.getSecondsAtTime(2)).to.be.closeTo(0, 0.01);
+			expect(source.getSecondsAtTime(3)).to.be.closeTo(0, 0.01);
+			expect(source.getSecondsAtTime(4)).to.be.closeTo(1, 0.01);
+			expect(source.getSecondsAtTime(5)).to.be.closeTo(1, 0.01);
+			source.start(1).pause(2);
+			expect(source.getSecondsAtTime(1)).to.be.closeTo(0, 0.01);
+			expect(source.getSecondsAtTime(2)).to.be.closeTo(1, 0.01);
+			expect(source.getSecondsAtTime(3)).to.be.closeTo(1, 0.01);
+			expect(source.getSecondsAtTime(4)).to.be.closeTo(2, 0.01);
+			expect(source.getSecondsAtTime(5)).to.be.closeTo(2, 0.01);
+			source.cancel(4);
+			expect(source.getSecondsAtTime(1)).to.be.closeTo(0, 0.01);
+			expect(source.getSecondsAtTime(2)).to.be.closeTo(1, 0.01);
+			expect(source.getSecondsAtTime(3)).to.be.closeTo(1, 0.01);
+			expect(source.getSecondsAtTime(4)).to.be.closeTo(2, 0.01);
+			expect(source.getSecondsAtTime(5)).to.be.closeTo(3, 0.01);
 			source.dispose();
 		});
 	});

--- a/Tone/core/clock/TickSource.ts
+++ b/Tone/core/clock/TickSource.ts
@@ -13,19 +13,19 @@ interface TickSourceOptions extends ToneWithContextOptions {
 	units: "bpm" | "hertz";
 }
 
-interface TickSourceOffsetEvent {
+interface TickSourceOffsetEvent extends TimelineEvent {
 	ticks: number;
 	time: number;
 	seconds: number;
 }
 
-interface TickSourceTicksAtTimeEvent {
+interface TickSourceTicksAtTimeEvent extends TimelineEvent {
 	state: PlaybackState;
 	time: number;
 	ticks: number;
 }
 
-interface TickSourceSecondsAtTimeEvent {
+interface TickSourceSecondsAtTimeEvent extends TimelineEvent {
 	state: PlaybackState;
 	time: number;
 	seconds: number;
@@ -112,6 +112,8 @@ export class TickSource<TypeName extends "bpm" | "hertz"> extends ToneWithContex
 			if (isDefined(offset)) {
 				this.setTicksAtTime(offset, computedTime);
 			}
+			this._ticksAtTime.cancel(computedTime);
+			this._secondsAtTime.cancel(computedTime);
 		}
 		return this;
 	}
@@ -133,6 +135,8 @@ export class TickSource<TypeName extends "bpm" | "hertz"> extends ToneWithContex
 		this._state.cancel(computedTime);
 		this._state.setStateAtTime("stopped", computedTime);
 		this.setTicksAtTime(0, computedTime);
+		this._ticksAtTime.cancel(computedTime);
+		this._secondsAtTime.cancel(computedTime);
 		return this;
 	}
 
@@ -144,6 +148,8 @@ export class TickSource<TypeName extends "bpm" | "hertz"> extends ToneWithContex
 		const computedTime = this.toSeconds(time);
 		if (this._state.getValueAtTime(computedTime) === "started") {
 			this._state.setStateAtTime("paused", computedTime);
+			this._ticksAtTime.cancel(computedTime);
+			this._secondsAtTime.cancel(computedTime);
 		}
 		return this;
 	}
@@ -156,6 +162,8 @@ export class TickSource<TypeName extends "bpm" | "hertz"> extends ToneWithContex
 		time = this.toSeconds(time);
 		this._state.cancel(time);
 		this._tickOffset.cancel(time);
+		this._ticksAtTime.cancel(time);
+		this._secondsAtTime.cancel(time);
 		return this;
 	}
 
@@ -299,6 +307,8 @@ export class TickSource<TypeName extends "bpm" | "hertz"> extends ToneWithContex
 			ticks,
 			time,
 		});
+		this._ticksAtTime.cancel(time);
+		this._secondsAtTime.cancel(time);
 		return this;
 	}
 


### PR DESCRIPTION
Resolves #370

When TickSource.getTicksAtTime() or TickSource.getSecondsAtTime(), TickSource memoizes the ticks or seconds at the most recent event that has a state other than "started". The memoized values are used in subsequent calls.