### PR TITLE
actually close audio context when disposing it

### DIFF
--- a/Tone/core/context/Context.test.ts
+++ b/Tone/core/context/Context.test.ts
@@ -120,8 +120,7 @@ describe("Context", () => {
 			await context.resume();
 			await new Promise<void>((done) => setTimeout(() => done(), 10));
 			expect(triggerChange).to.equal(true);
-			context.dispose();
-			return ac.close();
+			return context.dispose();
 		});
 	});
 

--- a/Tone/core/context/Context.ts
+++ b/Tone/core/context/Context.ts
@@ -95,6 +95,11 @@ export class Context extends BaseContext {
 	private _initialized = false;
 
 	/**
+	 * Private indicator if a close() has been called on the context, since close is async
+	 */
+	private _closeStarted = false;
+
+	/**
 	 * Indicates if the context is an OfflineAudioContext or an AudioContext
 	 */
 	readonly isOffline: boolean = false;
@@ -491,7 +496,8 @@ export class Context extends BaseContext {
 	 * any AudioNodes created from the context will be silent.
 	 */
 	async close(): Promise<void> {
-		if (isAudioContext(this._context)) {
+		if (isAudioContext(this._context) && (this.state !== "closed") && !this._closeStarted) {
+			this._closeStarted = true;
 			await this._context.close();
 		}
 		if (this._initialized) {

--- a/Tone/core/context/Context.ts
+++ b/Tone/core/context/Context.ts
@@ -536,6 +536,7 @@ export class Context extends BaseContext {
 		Object.keys(this._constants).map((val) =>
 			this._constants[val].disconnect()
 		);
+		this.close();
 		return this;
 	}
 


### PR DESCRIPTION
When looking into #1037 I found that, contrary to the docs, calling `context.dispose()` does not really close the audio context. Looks like just an oversight. This fixes the following bug:
```
Tone.getContext().dispose();
// ...
console.log(Tone.getContext().state); // "running", expected "closed"
```


