### PR TITLE
Use reciprocal of tempo when syncing time signals to Transport

### DIFF
--- a/Tone/signal/Signal.test.ts
+++ b/Tone/signal/Signal.test.ts
@@ -480,6 +480,15 @@ describe("Signal", () => {
 			}, 10);
 		});
 
+		it("keeps the ratio of a time signal when the bpm changes", () => {
+			return ConstantOutput(({ transport }) => {
+				transport.bpm.value = 120;
+				const sig = new Signal("4n", "time").toDestination();
+				transport.syncSignal(sig);
+				transport.bpm.value = 240;
+			}, 0.25);
+		});
+
 		it("outputs 0 when the signal is 0", () => {
 			return ConstantOutput(({ transport }) => {
 				transport.bpm.value = 120;


### PR DESCRIPTION
Previously, signals with time units were synced to Transport by connecting it to the tempo signal, which has frequency units. This unit mismatch caused incorrect behavior, e.g. a time signal would double instead of halving as expected when bpm doubles. Now, signals with time units are connected to the reciprocal of the tempo signal instead, which also has time units.

fixes #879


