### PR TITLE
Load only a single AudioWorklet

### DIFF
--- a/Tone/component/filter/FeedbackCombFilter.test.ts
+++ b/Tone/component/filter/FeedbackCombFilter.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import { FeedbackCombFilter } from "./FeedbackCombFilter";
+import { BitCrusher } from "Tone/effect/BitCrusher";
 import { BasicTests } from "test/helper/Basic";
 import { PassAudio } from "test/helper/PassAudio";
 import { Offline } from "test/helper/Offline";
@@ -75,6 +76,21 @@ describe("FeedbackCombFilter", () => {
 				expect(buffer.getValueAtTime(0.301)).to.equal(0.25);
 			});
 		});
+	});
+
+	it("should be usable with the BitCrusher", (done) => {
+		new FeedbackCombFilter();
+		new BitCrusher(4);
+
+		const handle = setTimeout(() => {
+			window.onunhandledrejection = null;
+			done();
+		}, 100);
+
+		window.onunhandledrejection = (event) => {
+			done(event.reason);
+			clearTimeout(handle);
+		};
 	});
 });
 

--- a/Tone/core/context/BaseContext.ts
+++ b/Tone/core/context/BaseContext.ts
@@ -105,8 +105,7 @@ export abstract class BaseContext
 	abstract get rawContext(): AnyAudioContext;
 
 	abstract addAudioWorkletModule(
-		_url: string,
-		_name: string
+		_url: string
 	): Promise<void>;
 
 	abstract lookAhead: number;

--- a/Tone/core/context/DummyContext.test.ts
+++ b/Tone/core/context/DummyContext.test.ts
@@ -25,7 +25,7 @@ describe("DummyContext", () => {
 		context.decodeAudioData(new Float32Array(100));
 		context.createAudioWorkletNode("test.js");
 		context.rawContext;
-		context.addAudioWorkletModule("test.js", "test");
+		context.addAudioWorkletModule("test.js");
 		context.resume();
 		context.setTimeout(() => {}, 1);
 		context.clearTimeout(1);

--- a/Tone/core/context/DummyContext.ts
+++ b/Tone/core/context/DummyContext.ts
@@ -127,7 +127,7 @@ export class DummyContext extends BaseContext {
 		return {} as AnyAudioContext;
 	}
 
-	async addAudioWorkletModule(_url: string, _name: string): Promise<void> {
+	async addAudioWorkletModule(_url: string): Promise<void> {
 		return Promise.resolve();
 	}
 

--- a/Tone/core/worklet/ToneAudioWorklet.ts
+++ b/Tone/core/worklet/ToneAudioWorklet.ts
@@ -53,7 +53,7 @@ export abstract class ToneAudioWorklet<Options extends ToneAudioWorkletOptions> 
 		this._dummyParam = this._dummyGain.gain;
 
 		// Register the processor
-		this.context.addAudioWorkletModule(blobUrl, name).then(() => {
+		this.context.addAudioWorkletModule(blobUrl).then(() => {
 			// create the worklet when it's read
 			if (!this.disposed) {
 				this._worklet = this.context.createAudioWorkletNode(name, this.workletOptions);

--- a/Tone/effect/BitCrusher.test.ts
+++ b/Tone/effect/BitCrusher.test.ts
@@ -1,4 +1,5 @@
 import { BitCrusher } from "./BitCrusher";
+import { FeedbackCombFilter } from "Tone/component/filter/FeedbackCombFilter";
 import { Oscillator } from "Tone/source/oscillator/Oscillator";
 import { BasicTests } from "test/helper/Basic";
 import { EffectTests } from "test/helper/EffectTests";
@@ -37,6 +38,21 @@ describe("BitCrusher", () => {
 			expect(crusher.get().bits).to.equal(5);
 			crusher.dispose();
 		});
+	});
+
+	it("should be usable with the FeedbackCombFilter", (done) => {
+		new BitCrusher(4);
+		new FeedbackCombFilter();
+
+		const handle = setTimeout(() => {
+			window.onunhandledrejection = null;
+			done();
+		}, 100);
+
+		window.onunhandledrejection = (event) => {
+			done(event.reason);
+			clearTimeout(handle);
+		};
 	});
 });
 


### PR DESCRIPTION
This PR changes the worklet loading code to expect only a single module and not a module per AudioWorklet. Before the code was expecting a module for each AudioWorklet but in fact only one module is used. This caused the bug reported here: #1038.

As always, please let me know if there is anything I should change.