### PR TITLE
Fix: typo and broken link in TransportTime and TransportTimeClass docs

### DIFF
--- a/Tone/core/type/TransportTime.ts
+++ b/Tone/core/type/TransportTime.ts
@@ -4,7 +4,7 @@ import { TimeClass } from "./Time";
 import { TimeBaseUnit, TimeValue } from "./TimeBase";
 
 /**
- * TransportTime is a the time along the Transport's
+ * TransportTime is a time along the Transport's
  * timeline. It is similar to Tone.Time, but instead of evaluating
  * against the AudioContext's clock, it is evaluated against
  * the Transport's position. See [TransportTime wiki](https://github.com/Tonejs/Tone.js/wiki/TransportTime).
@@ -23,8 +23,8 @@ export class TransportTimeClass<Type extends Seconds | Ticks = Seconds> extends 
 }
 
 /**
- * TransportTime is a the time along the Transport's
- * timeline. It is similar to [[Time]], but instead of evaluating
+ * TransportTime is a time along the Transport's
+ * timeline. It is similar to Tone.Time, but instead of evaluating
  * against the AudioContext's clock, it is evaluated against
  * the Transport's position. See [TransportTime wiki](https://github.com/Tonejs/Tone.js/wiki/TransportTime).
  * @category Unit


### PR DESCRIPTION
Fixed a typo in `TransportTime.ts`.  `[[Time]]` is a broken link, so updated to `Tone.Time` to match what's written in the `TransportTimeClass` section. 


