### PR TITLE
docs typo fix

### DIFF
--- a/Tone/source/Source.ts
+++ b/Tone/source/Source.ts
@@ -53,7 +53,7 @@ export abstract class Source<
 	private _volume: Volume;
 
 	/**
-	 * The output note
+	 * The output node
 	 */
 	output: OutputNode;
 


### PR DESCRIPTION
Yes it's just one character, but it affects a not insignificant meaning change, and propagates into a lot of different Tone docs pages 😅 


