### PR TITLE
README: update `travis-ci.org` deprecated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Tone.js
 =========
 
-[![Build Status](https://travis-ci.org/Tonejs/Tone.js.svg?branch=dev)](https://travis-ci.org/Tonejs/Tone.js) [![codecov](https://codecov.io/gh/Tonejs/Tone.js/branch/dev/graph/badge.svg)](https://codecov.io/gh/Tonejs/Tone.js)
+[![Build Status](https://travis-ci.com/Tonejs/Tone.js.svg?branch=dev)](https://app.travis-ci.com/github/Tonejs/Tone.js) [![codecov](https://codecov.io/gh/Tonejs/Tone.js/branch/dev/graph/badge.svg)](https://codecov.io/gh/Tonejs/Tone.js)
 
 
 Tone.js is a Web Audio framework for creating interactive music in the browser. The architecture of Tone.js aims to be familiar to both musicians and audio programmers creating web-based audio applications. On the high-level, Tone offers common DAW (digital audio workstation) features like a global transport for synchronizing and scheduling events as well as prebuilt synths and effects. Additionally, Tone provides high-performance building blocks to create your own synthesizers, effects, and complex control signals.
@@ -236,7 +236,7 @@ Tone.js makes extensive use of the native Web Audio Nodes such as the GainNode a
 
 # Testing
 
-Tone.js runs an extensive test suite using [mocha](https://mochajs.org/) and [chai](http://chaijs.com/) with nearly 100% coverage. Each commit and pull request is run on [Travis-CI](https://travis-ci.org/Tonejs/Tone.js/) across browsers and versions. Passing builds on the 'dev' branch are published on npm as `tone@next`. 
+Tone.js runs an extensive test suite using [mocha](https://mochajs.org/) and [chai](http://chaijs.com/) with nearly 100% coverage. Each commit and pull request is run on [Travis-CI](https://app.travis-ci.com/github/Tonejs/Tone.js) across browsers and versions. Passing builds on the 'dev' branch are published on npm as `tone@next`. 
 
 # Contributing
 


### PR DESCRIPTION
Due to [Travis CI - ORG Shutdown](https://blog.travis-ci.com/2021-05-07-orgshutdown), update the links containing `travis-ci.org` to `travis-ci.com` domain in `README.md` file 
