### PR TITLE
Travis CI config: update `travis-ci.org` deprecated links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
     - "14"
 install:
     - npm install
-    - git config --global user.email "travis@travis-ci.org"
+    - git config --global user.email "travis@travis-ci.com"
     - git config --global user.name "Travis CI"
 script:
     - npm run test


### PR DESCRIPTION
Due to [Travis CI - ORG Shutdown](https://blog.travis-ci.com/2021-05-07-orgshutdown), you might probably need to update the links containing `travis-ci.org` to `travis-ci.com` domain in `.travis.yml` config file 
