### PR TITLE
Add `Time.toBarsBeatsSixteenthsValues()` to get numerical values

### DIFF
--- a/Tone/core/clock/Transport.ts
+++ b/Tone/core/clock/Transport.ts
@@ -573,12 +573,12 @@ export class Transport
 	 * The Transport's position in Bars:Beats:Sixteenths.
 	 * Setting the value will jump to that position right away.
 	 */
-	get position(): BarsBeatsSixteenths | Time {
+	get position(): TransportTime {
 		const now = this.now();
 		const ticks = this._clock.getTicksAtTime(now);
 		return new TicksClass(this.context, ticks).toBarsBeatsSixteenths();
 	}
-	set position(progress: Time) {
+	set position(progress: TransportTime) {
 		const ticks = this.toTicks(progress);
 		this.ticks = ticks;
 	}

--- a/Tone/core/type/Time.ts
+++ b/Tone/core/type/Time.ts
@@ -92,19 +92,29 @@ export class TimeClass<Type extends Seconds | Ticks = Seconds, Unit extends stri
 	 * Return the time encoded as Bars:Beats:Sixteenths.
 	 */
 	toBarsBeatsSixteenths(): BarsBeatsSixteenths {
-		const quarterTime = this._beatsToUnits(1);
-		let quarters = this.valueOf() / quarterTime;
-		quarters = parseFloat(quarters.toFixed(4));
-		const measures = Math.floor(quarters / this._getTimeSignature());
-		let sixteenths = (quarters % 1) * 4;
-		quarters = Math.floor(quarters) % this._getTimeSignature();
-		const sixteenthString = sixteenths.toString();
+		const [measures, quarters, sixteenths] = this.toBarsBeatsSixteenthsValues();
+		const measureString = measures.toFixed(0);
+		const quarterString = quarters.toFixed(4);
+		let sixteenthString = sixteenths.toFixed(3);
 		if (sixteenthString.length > 3) {
 			// the additional parseFloat removes insignificant trailing zeroes
-			sixteenths = parseFloat(parseFloat(sixteenthString).toFixed(3));
+			sixteenthString = parseFloat(sixteenthString).toString();
 		}
-		const progress = [measures, quarters, sixteenths];
-		return progress.join(":");
+		const parts = [measureString, quarterString, sixteenthString];
+		return parts.join(":");
+	}
+
+	/**
+	 * Return the time as a tuple of [bars, beats, sixteenths].
+	 */
+	toBarsBeatsSixteenthsValues(): [number, number, number] {
+		const quarterTime = this._beatsToUnits(1);
+		const totalQuarters = this.valueOf() / quarterTime;
+		const timeSignature = this._getTimeSignature();
+		const measures = Math.floor(totalQuarters / timeSignature);
+		const quarters = Math.floor(totalQuarters) % timeSignature;
+		const sixteenths = (totalQuarters % 1) * 4;
+		return [measures, quarters, sixteenths];
 	}
 
 	/**
@@ -136,7 +146,7 @@ export class TimeClass<Type extends Seconds | Ticks = Seconds, Unit extends stri
 }
 
 /**
- * Create a TimeClass from a time string or number. The time is computed against the 
+ * Create a TimeClass from a time string or number. The time is computed against the
  * global Tone.Context. To use a specific context, use [[TimeClass]]
  * @param value A value which represents time
  * @param units The value's units if they can't be inferred by the value.

--- a/Tone/source/buffer/Player.test.ts
+++ b/Tone/source/buffer/Player.test.ts
@@ -709,15 +709,15 @@ describe("Player", () => {
 					setTimeout(() => {
 						player.restart(undefined, undefined, 1);
 						const checkStopTimes = new Set();
-						// @ts-ignore
-						player._activeSources.forEach(source => {
-							// @ts-ignore
-							checkStopTimes.add(source._stopTime);
+						// eslint-disable-next-line dot-notation
+						player["_activeSources"].forEach(source => {
+							// eslint-disable-next-line dot-notation
+							checkStopTimes.add(source["_stopTime"]);
 						});
 						getContext().lookAhead = originalLookAhead;
 						// ensure each source has a different stopTime
-						// @ts-ignore
-						expect(checkStopTimes.size).to.equal(player._activeSources.size);
+						// eslint-disable-next-line dot-notation
+						expect(checkStopTimes.size).to.equal(player["_activeSources"].size);
 						done();
 					}, 250);
 				},

--- a/Tone/source/buffer/Player.test.ts
+++ b/Tone/source/buffer/Player.test.ts
@@ -709,11 +709,14 @@ describe("Player", () => {
 					setTimeout(() => {
 						player.restart(undefined, undefined, 1);
 						const checkStopTimes = new Set();
+						// @ts-ignore
 						player._activeSources.forEach(source => {
+							// @ts-ignore
 							checkStopTimes.add(source._stopTime);
 						});
 						getContext().lookAhead = originalLookAhead;
 						// ensure each source has a different stopTime
+						// @ts-ignore
 						expect(checkStopTimes.size).to.equal(player._activeSources.size);
 						done();
 					}, 250);


### PR DESCRIPTION
Resolves #1142

Would it be reasonable to call this method `toBarsBeatsSixteenths()` and rename the existing one something like `toTimeString()`?