### PR TITLE
Refactor `options` before `super`

### DIFF
--- a/Tone/component/analysis/Analyser.ts
+++ b/Tone/component/analysis/Analyser.ts
@@ -62,17 +62,12 @@ export class Analyser extends ToneAudioNode<AnalyserOptions> {
 	constructor(type?: AnalyserType, size?: number);
 	constructor(options?: Partial<AnalyserOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Analyser.getDefaults(), arguments, [
-				"type",
-				"size",
-			])
-		);
 		const options = optionsFromArguments(
 			Analyser.getDefaults(),
 			arguments,
 			["type", "size"]
 		);
+		super(options);
 
 		this.input =
 			this.output =

--- a/Tone/component/analysis/FFT.ts
+++ b/Tone/component/analysis/FFT.ts
@@ -32,10 +32,10 @@ export class FFT extends MeterBase<FFTOptions> {
 	constructor(size?: PowerOfTwo);
 	constructor(options?: Partial<FFTOptions>);
 	constructor() {
-		super(optionsFromArguments(FFT.getDefaults(), arguments, ["size"]));
 		const options = optionsFromArguments(FFT.getDefaults(), arguments, [
 			"size",
 		]);
+		super(options);
 
 		this.normalRange = options.normalRange;
 		this._analyser.type = "fft";

--- a/Tone/component/analysis/Follower.ts
+++ b/Tone/component/analysis/Follower.ts
@@ -50,16 +50,12 @@ export class Follower extends ToneAudioNode<FollowerOptions> {
 	constructor(smoothing?: Time);
 	constructor(options?: Partial<FollowerOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Follower.getDefaults(), arguments, [
-				"smoothing",
-			])
-		);
 		const options = optionsFromArguments(
 			Follower.getDefaults(),
 			arguments,
 			["smoothing"]
 		);
+		super(options);
 
 		this._abs = this.input = new Abs({ context: this.context });
 		this._lowpass = this.output = new OnePoleFilter({

--- a/Tone/component/analysis/Meter.ts
+++ b/Tone/component/analysis/Meter.ts
@@ -55,12 +55,10 @@ export class Meter extends MeterBase<MeterOptions> {
 	constructor(smoothing?: NormalRange);
 	constructor(options?: Partial<MeterOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Meter.getDefaults(), arguments, ["smoothing"])
-		);
 		const options = optionsFromArguments(Meter.getDefaults(), arguments, [
 			"smoothing",
 		]);
+		super(options);
 
 		this.input =
 			this.output =

--- a/Tone/component/analysis/Waveform.ts
+++ b/Tone/component/analysis/Waveform.ts
@@ -22,14 +22,12 @@ export class Waveform extends MeterBase<WaveformOptions> {
 	constructor(size?: PowerOfTwo);
 	constructor(options?: Partial<WaveformOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Waveform.getDefaults(), arguments, ["size"])
-		);
 		const options = optionsFromArguments(
 			Waveform.getDefaults(),
 			arguments,
 			["size"]
 		);
+		super(options);
 
 		this._analyser.type = "waveform";
 		this.size = options.size;

--- a/Tone/component/channel/Channel.ts
+++ b/Tone/component/channel/Channel.ts
@@ -63,16 +63,11 @@ export class Channel extends ToneAudioNode<ChannelOptions> {
 	constructor(volume?: Decibels, pan?: AudioRange);
 	constructor(options?: Partial<ChannelOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Channel.getDefaults(), arguments, [
-				"volume",
-				"pan",
-			])
-		);
 		const options = optionsFromArguments(Channel.getDefaults(), arguments, [
 			"volume",
 			"pan",
 		]);
+		super(options);
 
 		this._solo = this.input = new Solo({
 			solo: options.solo,

--- a/Tone/component/channel/CrossFade.ts
+++ b/Tone/component/channel/CrossFade.ts
@@ -100,18 +100,12 @@ export class CrossFade extends ToneAudioNode<CrossFadeOptions> {
 	constructor(fade?: NormalRange);
 	constructor(options?: Partial<CrossFadeOptions>);
 	constructor() {
-		super(
-			Object.assign(
-				optionsFromArguments(CrossFade.getDefaults(), arguments, [
-					"fade",
-				])
-			)
-		);
 		const options = optionsFromArguments(
 			CrossFade.getDefaults(),
 			arguments,
 			["fade"]
 		);
+		super(options);
 
 		this.fade = new Signal({
 			context: this.context,

--- a/Tone/component/channel/Merge.ts
+++ b/Tone/component/channel/Merge.ts
@@ -44,12 +44,10 @@ export class Merge extends ToneAudioNode<MergeOptions> {
 	constructor(channels?: Positive);
 	constructor(options?: Partial<MergeOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Merge.getDefaults(), arguments, ["channels"])
-		);
 		const options = optionsFromArguments(Merge.getDefaults(), arguments, [
 			"channels",
 		]);
+		super(options);
 
 		this._merger =
 			this.output =

--- a/Tone/component/channel/MultibandSplit.ts
+++ b/Tone/component/channel/MultibandSplit.ts
@@ -106,17 +106,12 @@ export class MultibandSplit extends ToneAudioNode<MultibandSplitOptions> {
 	constructor(lowFrequency?: Frequency, highFrequency?: Frequency);
 	constructor(options?: Partial<MultibandSplitOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(MultibandSplit.getDefaults(), arguments, [
-				"lowFrequency",
-				"highFrequency",
-			])
-		);
 		const options = optionsFromArguments(
 			MultibandSplit.getDefaults(),
 			arguments,
 			["lowFrequency", "highFrequency"]
 		);
+		super(options);
 
 		this.lowFrequency = new Signal({
 			context: this.context,

--- a/Tone/component/channel/PanVol.ts
+++ b/Tone/component/channel/PanVol.ts
@@ -61,16 +61,11 @@ export class PanVol extends ToneAudioNode<PanVolOptions> {
 	constructor(pan?: AudioRange, volume?: Decibels);
 	constructor(options?: Partial<PanVolOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(PanVol.getDefaults(), arguments, [
-				"pan",
-				"volume",
-			])
-		);
 		const options = optionsFromArguments(PanVol.getDefaults(), arguments, [
 			"pan",
 			"volume",
 		]);
+		super(options);
 
 		this._panner = this.input = new Panner({
 			context: this.context,

--- a/Tone/component/channel/Panner.ts
+++ b/Tone/component/channel/Panner.ts
@@ -54,14 +54,10 @@ export class Panner extends ToneAudioNode<TonePannerOptions> {
 	 */
 	constructor(pan?: AudioRange);
 	constructor() {
-		super(
-			Object.assign(
-				optionsFromArguments(Panner.getDefaults(), arguments, ["pan"])
-			)
-		);
 		const options = optionsFromArguments(Panner.getDefaults(), arguments, [
 			"pan",
 		]);
+		super(options);
 
 		this.pan = new Param({
 			context: this.context,

--- a/Tone/component/channel/Panner3D.ts
+++ b/Tone/component/channel/Panner3D.ts
@@ -54,18 +54,12 @@ export class Panner3D extends ToneAudioNode<Panner3DOptions> {
 	constructor(positionX: number, positionY: number, positionZ: number);
 	constructor(options?: Partial<Panner3DOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Panner3D.getDefaults(), arguments, [
-				"positionX",
-				"positionY",
-				"positionZ",
-			])
-		);
 		const options = optionsFromArguments(
 			Panner3D.getDefaults(),
 			arguments,
 			["positionX", "positionY", "positionZ"]
 		);
+		super(options);
 
 		this._panner = this.input = this.output = this.context.createPanner();
 		// set some values

--- a/Tone/component/channel/Recorder.ts
+++ b/Tone/component/channel/Recorder.ts
@@ -57,8 +57,8 @@ export class Recorder extends ToneAudioNode<RecorderOptions> {
 
 	constructor(options?: Partial<RecorderOptions>);
 	constructor() {
-		super(optionsFromArguments(Recorder.getDefaults(), arguments));
 		const options = optionsFromArguments(Recorder.getDefaults(), arguments);
+		super(options);
 
 		this.input = new Gain({
 			context: this.context,

--- a/Tone/component/channel/Solo.ts
+++ b/Tone/component/channel/Solo.ts
@@ -34,10 +34,10 @@ export class Solo extends ToneAudioNode<SoloOptions> {
 	constructor(solo?: boolean);
 	constructor(options?: Partial<SoloOptions>);
 	constructor() {
-		super(optionsFromArguments(Solo.getDefaults(), arguments, ["solo"]));
 		const options = optionsFromArguments(Solo.getDefaults(), arguments, [
 			"solo",
 		]);
+		super(options);
 
 		this.input = this.output = new Gain({
 			context: this.context,

--- a/Tone/component/channel/Split.ts
+++ b/Tone/component/channel/Split.ts
@@ -33,12 +33,10 @@ export class Split extends ToneAudioNode<SplitOptions> {
 	constructor(channels?: number);
 	constructor(options?: Partial<SplitOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Split.getDefaults(), arguments, ["channels"])
-		);
 		const options = optionsFromArguments(Split.getDefaults(), arguments, [
 			"channels",
 		]);
+		super(options);
 
 		this._splitter =
 			this.input =

--- a/Tone/component/channel/Volume.ts
+++ b/Tone/component/channel/Volume.ts
@@ -54,12 +54,10 @@ export class Volume extends ToneAudioNode<VolumeOptions> {
 	constructor(volume?: Decibels);
 	constructor(options?: Partial<VolumeOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Volume.getDefaults(), arguments, ["volume"])
-		);
 		const options = optionsFromArguments(Volume.getDefaults(), arguments, [
 			"volume",
 		]);
+		super(options);
 
 		this.input = this.output = new Gain({
 			context: this.context,

--- a/Tone/component/dynamics/Compressor.ts
+++ b/Tone/component/dynamics/Compressor.ts
@@ -79,17 +79,12 @@ export class Compressor extends ToneAudioNode<CompressorOptions> {
 	constructor(threshold?: Decibels, ratio?: Positive);
 	constructor(options?: Partial<CompressorOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Compressor.getDefaults(), arguments, [
-				"threshold",
-				"ratio",
-			])
-		);
 		const options = optionsFromArguments(
 			Compressor.getDefaults(),
 			arguments,
 			["threshold", "ratio"]
 		);
+		super(options);
 
 		this.threshold = new Param({
 			minValue: this._compressor.threshold.minValue,

--- a/Tone/component/dynamics/Gate.ts
+++ b/Tone/component/dynamics/Gate.ts
@@ -54,18 +54,11 @@ export class Gate extends ToneAudioNode<GateOptions> {
 	constructor(threshold?: Decibels, smoothing?: Time);
 	constructor(options?: Partial<GateOptions>);
 	constructor() {
-		super(
-			Object.assign(
-				optionsFromArguments(Gate.getDefaults(), arguments, [
-					"threshold",
-					"smoothing",
-				])
-			)
-		);
 		const options = optionsFromArguments(Gate.getDefaults(), arguments, [
 			"threshold",
 			"smoothing",
 		]);
+		super(options);
 
 		this._follower = new Follower({
 			context: this.context,

--- a/Tone/component/dynamics/Limiter.ts
+++ b/Tone/component/dynamics/Limiter.ts
@@ -44,16 +44,10 @@ export class Limiter extends ToneAudioNode<LimiterOptions> {
 	constructor(threshold?: Decibels);
 	constructor(options?: Partial<LimiterOptions>);
 	constructor() {
-		super(
-			Object.assign(
-				optionsFromArguments(Limiter.getDefaults(), arguments, [
-					"threshold",
-				])
-			)
-		);
 		const options = optionsFromArguments(Limiter.getDefaults(), arguments, [
 			"threshold",
 		]);
+		super(options);
 
 		this._compressor =
 			this.input =

--- a/Tone/component/dynamics/MidSideCompressor.ts
+++ b/Tone/component/dynamics/MidSideCompressor.ts
@@ -49,15 +49,11 @@ export class MidSideCompressor extends ToneAudioNode<MidSideCompressorOptions> {
 
 	constructor(options?: RecursivePartial<MidSideCompressorOptions>);
 	constructor() {
-		super(
-			Object.assign(
-				optionsFromArguments(MidSideCompressor.getDefaults(), arguments)
-			)
-		);
 		const options = optionsFromArguments(
 			MidSideCompressor.getDefaults(),
 			arguments
 		);
+		super(options);
 
 		this._midSideSplit = this.input = new MidSideSplit({
 			context: this.context,

--- a/Tone/component/dynamics/MultibandCompressor.ts
+++ b/Tone/component/dynamics/MultibandCompressor.ts
@@ -71,18 +71,11 @@ export class MultibandCompressor extends ToneAudioNode<MultibandCompressorOption
 
 	constructor(options?: RecursivePartial<MultibandCompressorOptions>);
 	constructor() {
-		super(
-			Object.assign(
-				optionsFromArguments(
-					MultibandCompressor.getDefaults(),
-					arguments
-				)
-			)
-		);
 		const options = optionsFromArguments(
 			MultibandCompressor.getDefaults(),
 			arguments
 		);
+		super(options);
 
 		this._splitter = this.input = new MultibandSplit({
 			context: this.context,

--- a/Tone/component/envelope/Envelope.ts
+++ b/Tone/component/envelope/Envelope.ts
@@ -186,19 +186,12 @@ export class Envelope extends ToneAudioNode<EnvelopeOptions> {
 	);
 	constructor(options?: Partial<EnvelopeOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Envelope.getDefaults(), arguments, [
-				"attack",
-				"decay",
-				"sustain",
-				"release",
-			])
-		);
 		const options = optionsFromArguments(
 			Envelope.getDefaults(),
 			arguments,
 			["attack", "decay", "sustain", "release"]
 		);
+		super(options);
 
 		this.attack = options.attack;
 		this.decay = options.decay;

--- a/Tone/component/envelope/FrequencyEnvelope.ts
+++ b/Tone/component/envelope/FrequencyEnvelope.ts
@@ -62,19 +62,12 @@ export class FrequencyEnvelope extends Envelope {
 	);
 	constructor(options?: Partial<FrequencyEnvelopeOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(FrequencyEnvelope.getDefaults(), arguments, [
-				"attack",
-				"decay",
-				"sustain",
-				"release",
-			])
-		);
 		const options = optionsFromArguments(
 			FrequencyEnvelope.getDefaults(),
 			arguments,
 			["attack", "decay", "sustain", "release"]
 		);
+		super(options);
 
 		this._octaves = options.octaves;
 		this._baseFrequency = this.toFrequency(options.baseFrequency);

--- a/Tone/component/filter/BiquadFilter.ts
+++ b/Tone/component/filter/BiquadFilter.ts
@@ -61,17 +61,12 @@ export class BiquadFilter extends ToneAudioNode<BiquadFilterOptions> {
 	constructor(frequency?: Frequency, type?: BiquadFilterType);
 	constructor(options?: Partial<BiquadFilterOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(BiquadFilter.getDefaults(), arguments, [
-				"frequency",
-				"type",
-			])
-		);
 		const options = optionsFromArguments(
 			BiquadFilter.getDefaults(),
 			arguments,
 			["frequency", "type"]
 		);
+		super(options);
 
 		this._filter = this.context.createBiquadFilter();
 		this.input = this.output = this._filter;

--- a/Tone/component/filter/Convolver.ts
+++ b/Tone/component/filter/Convolver.ts
@@ -50,17 +50,12 @@ export class Convolver extends ToneAudioNode<ConvolverOptions> {
 	);
 	constructor(options?: Partial<ConvolverOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Convolver.getDefaults(), arguments, [
-				"url",
-				"onload",
-			])
-		);
 		const options = optionsFromArguments(
 			Convolver.getDefaults(),
 			arguments,
 			["url", "onload"]
 		);
+		super(options);
 
 		this._buffer = new ToneAudioBuffer(options.url, (buffer) => {
 			this.buffer = buffer;

--- a/Tone/component/filter/EQ3.ts
+++ b/Tone/component/filter/EQ3.ts
@@ -90,18 +90,12 @@ export class EQ3 extends ToneAudioNode<EQ3Options> {
 	constructor(lowLevel?: Decibels, midLevel?: Decibels, highLevel?: Decibels);
 	constructor(options: Partial<EQ3Options>);
 	constructor() {
-		super(
-			optionsFromArguments(EQ3.getDefaults(), arguments, [
-				"low",
-				"mid",
-				"high",
-			])
-		);
 		const options = optionsFromArguments(EQ3.getDefaults(), arguments, [
 			"low",
 			"mid",
 			"high",
 		]);
+		super(options);
 
 		this.input = this._multibandSplit = new MultibandSplit({
 			context: this.context,

--- a/Tone/component/filter/FeedbackCombFilter.ts
+++ b/Tone/component/filter/FeedbackCombFilter.ts
@@ -48,17 +48,12 @@ export class FeedbackCombFilter extends ToneAudioWorklet<FeedbackCombFilterOptio
 	constructor(delayTime?: Time, resonance?: NormalRange);
 	constructor(options?: RecursivePartial<FeedbackCombFilterOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(FeedbackCombFilter.getDefaults(), arguments, [
-				"delayTime",
-				"resonance",
-			])
-		);
 		const options = optionsFromArguments(
 			FeedbackCombFilter.getDefaults(),
 			arguments,
 			["delayTime", "resonance"]
 		);
+		super(options);
 
 		this.input = new Gain({ context: this.context });
 		this.output = new Gain({ context: this.context });

--- a/Tone/component/filter/Filter.ts
+++ b/Tone/component/filter/Filter.ts
@@ -73,18 +73,12 @@ export class Filter extends ToneAudioNode<FilterOptions> {
 	);
 	constructor(options?: Partial<FilterOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Filter.getDefaults(), arguments, [
-				"frequency",
-				"type",
-				"rolloff",
-			])
-		);
 		const options = optionsFromArguments(Filter.getDefaults(), arguments, [
 			"frequency",
 			"type",
 			"rolloff",
 		]);
+		super(options);
 
 		this._filters = [];
 

--- a/Tone/component/filter/LowpassCombFilter.ts
+++ b/Tone/component/filter/LowpassCombFilter.ts
@@ -60,18 +60,12 @@ export class LowpassCombFilter extends ToneAudioNode<LowpassCombFilterOptions> {
 	);
 	constructor(options?: RecursivePartial<LowpassCombFilterOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(LowpassCombFilter.getDefaults(), arguments, [
-				"delayTime",
-				"resonance",
-				"dampening",
-			])
-		);
 		const options = optionsFromArguments(
 			LowpassCombFilter.getDefaults(),
 			arguments,
 			["delayTime", "resonance", "dampening"]
 		);
+		super(options);
 
 		this._combFilter = this.output = new FeedbackCombFilter({
 			context: this.context,

--- a/Tone/component/filter/OnePoleFilter.ts
+++ b/Tone/component/filter/OnePoleFilter.ts
@@ -51,17 +51,12 @@ export class OnePoleFilter extends ToneAudioNode<OnePoleFilterOptions> {
 	constructor(frequency?: Frequency, type?: OnePoleFilterType);
 	constructor(options?: Partial<OnePoleFilterOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(OnePoleFilter.getDefaults(), arguments, [
-				"frequency",
-				"type",
-			])
-		);
 		const options = optionsFromArguments(
 			OnePoleFilter.getDefaults(),
 			arguments,
 			["frequency", "type"]
 		);
+		super(options);
 
 		this._frequency = options.frequency;
 		this._type = options.type;

--- a/Tone/core/clock/Clock.ts
+++ b/Tone/core/clock/Clock.ts
@@ -80,16 +80,11 @@ export class Clock<TypeName extends "bpm" | "hertz" = "hertz">
 	constructor(callback?: ClockCallback, frequency?: Frequency);
 	constructor(options: Partial<ClockOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Clock.getDefaults(), arguments, [
-				"callback",
-				"frequency",
-			])
-		);
 		const options = optionsFromArguments(Clock.getDefaults(), arguments, [
 			"callback",
 			"frequency",
 		]);
+		super(options);
 
 		this.callback = options.callback;
 		this._tickSource = new TickSource({

--- a/Tone/core/clock/TickParam.ts
+++ b/Tone/core/clock/TickParam.ts
@@ -44,14 +44,12 @@ export class TickParam<
 	constructor(value?: number);
 	constructor(options: Partial<TickParamOptions<TypeName>>);
 	constructor() {
-		super(
-			optionsFromArguments(TickParam.getDefaults(), arguments, ["value"])
-		);
 		const options = optionsFromArguments(
 			TickParam.getDefaults(),
 			arguments,
 			["value"]
 		);
+		super(options);
 
 		// set the multiplier
 		this._multiplier = options.multiplier;

--- a/Tone/core/clock/TickSignal.ts
+++ b/Tone/core/clock/TickSignal.ts
@@ -36,14 +36,12 @@ export class TickSignal<
 	constructor(value?: UnitMap[TypeName]);
 	constructor(options: Partial<TickSignalOptions<TypeName>>);
 	constructor() {
-		super(
-			optionsFromArguments(TickSignal.getDefaults(), arguments, ["value"])
-		);
 		const options = optionsFromArguments(
 			TickSignal.getDefaults(),
 			arguments,
 			["value"]
 		);
+		super(options);
 
 		this.input = this._param = new TickParam({
 			context: this.context,

--- a/Tone/core/clock/TickSource.ts
+++ b/Tone/core/clock/TickSource.ts
@@ -79,16 +79,12 @@ export class TickSource<
 	constructor(frequency?: number);
 	constructor(options?: Partial<TickSourceOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(TickSource.getDefaults(), arguments, [
-				"frequency",
-			])
-		);
 		const options = optionsFromArguments(
 			TickSource.getDefaults(),
 			arguments,
 			["frequency"]
 		);
+		super(options);
 
 		this.frequency = new TickSignal({
 			context: this.context,

--- a/Tone/core/clock/Transport.ts
+++ b/Tone/core/clock/Transport.ts
@@ -188,11 +188,11 @@ export class TransportClass
 
 	constructor(options?: Partial<TransportOptions>);
 	constructor() {
-		super(optionsFromArguments(TransportClass.getDefaults(), arguments));
 		const options = optionsFromArguments(
 			TransportClass.getDefaults(),
 			arguments
 		);
+		super(options);
 
 		// CLOCK/TEMPO
 		this._ppq = options.ppq;

--- a/Tone/core/context/Delay.ts
+++ b/Tone/core/context/Delay.ts
@@ -54,17 +54,11 @@ export class Delay extends ToneAudioNode<DelayOptions> {
 	constructor(delayTime?: Time, maxDelay?: Time);
 	constructor(options?: Partial<DelayOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Delay.getDefaults(), arguments, [
-				"delayTime",
-				"maxDelay",
-			])
-		);
-
 		const options = optionsFromArguments(Delay.getDefaults(), arguments, [
 			"delayTime",
 			"maxDelay",
 		]);
+		super(options);
 
 		const maxDelayInSeconds = this.toSeconds(options.maxDelay);
 		this._maxDelay = Math.max(

--- a/Tone/core/context/Destination.ts
+++ b/Tone/core/context/Destination.ts
@@ -48,11 +48,11 @@ export class DestinationClass extends ToneAudioNode<DestinationOptions> {
 
 	constructor(options: Partial<DestinationOptions>);
 	constructor() {
-		super(optionsFromArguments(DestinationClass.getDefaults(), arguments));
 		const options = optionsFromArguments(
 			DestinationClass.getDefaults(),
 			arguments
 		);
+		super(options);
 
 		connectSeries(
 			this.input,

--- a/Tone/core/context/Gain.ts
+++ b/Tone/core/context/Gain.ts
@@ -56,16 +56,11 @@ export class Gain<
 	constructor(gain?: UnitMap[TypeName], units?: TypeName);
 	constructor(options?: Partial<GainOptions<TypeName>>);
 	constructor() {
-		super(
-			optionsFromArguments(Gain.getDefaults(), arguments, [
-				"gain",
-				"units",
-			])
-		);
 		const options = optionsFromArguments(Gain.getDefaults(), arguments, [
 			"gain",
 			"units",
 		]);
+		super(options);
 
 		this.gain = new Param({
 			context: this.context,

--- a/Tone/core/context/Param.ts
+++ b/Tone/core/context/Param.ts
@@ -113,19 +113,12 @@ export class Param<TypeName extends UnitName = "number">
 	constructor(param: AudioParam, units?: TypeName, convert?: boolean);
 	constructor(options: Partial<ParamOptions<TypeName>>);
 	constructor() {
-		super(
-			optionsFromArguments(Param.getDefaults(), arguments, [
-				"param",
-				"units",
-				"convert",
-			])
-		);
-
 		const options = optionsFromArguments(Param.getDefaults(), arguments, [
 			"param",
 			"units",
 			"convert",
 		]);
+		super(options);
 
 		assert(
 			isDefined(options.param) &&

--- a/Tone/effect/AutoFilter.ts
+++ b/Tone/effect/AutoFilter.ts
@@ -50,18 +50,12 @@ export class AutoFilter extends LFOEffect<AutoFilterOptions> {
 	);
 	constructor(options?: Partial<AutoFilterOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(AutoFilter.getDefaults(), arguments, [
-				"frequency",
-				"baseFrequency",
-				"octaves",
-			])
-		);
 		const options = optionsFromArguments(
 			AutoFilter.getDefaults(),
 			arguments,
 			["frequency", "baseFrequency", "octaves"]
 		);
+		super(options);
 
 		this.filter = new Filter(
 			Object.assign(options.filter, {

--- a/Tone/effect/AutoPanner.ts
+++ b/Tone/effect/AutoPanner.ts
@@ -32,16 +32,12 @@ export class AutoPanner extends LFOEffect<AutoPannerOptions> {
 	constructor(frequency?: Frequency);
 	constructor(options?: Partial<AutoPannerOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(AutoPanner.getDefaults(), arguments, [
-				"frequency",
-			])
-		);
 		const options = optionsFromArguments(
 			AutoPanner.getDefaults(),
 			arguments,
 			["frequency"]
 		);
+		super(options);
 
 		this._panner = new Panner({
 			context: this.context,

--- a/Tone/effect/AutoWah.ts
+++ b/Tone/effect/AutoWah.ts
@@ -101,18 +101,12 @@ export class AutoWah extends Effect<AutoWahOptions> {
 	);
 	constructor(options?: Partial<AutoWahOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(AutoWah.getDefaults(), arguments, [
-				"baseFrequency",
-				"octaves",
-				"sensitivity",
-			])
-		);
 		const options = optionsFromArguments(AutoWah.getDefaults(), arguments, [
 			"baseFrequency",
 			"octaves",
 			"sensitivity",
 		]);
+		super(options);
 
 		this._follower = new Follower({
 			context: this.context,

--- a/Tone/effect/BitCrusher.ts
+++ b/Tone/effect/BitCrusher.ts
@@ -44,14 +44,12 @@ export class BitCrusher extends Effect<BitCrusherOptions> {
 	constructor(bits?: Positive);
 	constructor(options?: Partial<BitCrusherWorkletOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(BitCrusher.getDefaults(), arguments, ["bits"])
-		);
 		const options = optionsFromArguments(
 			BitCrusher.getDefaults(),
 			arguments,
 			["bits"]
 		);
+		super(options);
 
 		this._bitCrusherWorklet = new BitCrusherWorklet({
 			context: this.context,
@@ -93,11 +91,11 @@ class BitCrusherWorklet extends ToneAudioWorklet<BitCrusherWorkletOptions> {
 
 	constructor(options?: Partial<BitCrusherWorkletOptions>);
 	constructor() {
-		super(optionsFromArguments(BitCrusherWorklet.getDefaults(), arguments));
 		const options = optionsFromArguments(
 			BitCrusherWorklet.getDefaults(),
 			arguments
 		);
+		super(options);
 
 		this.input = new Gain({ context: this.context });
 		this.output = new Gain({ context: this.context });

--- a/Tone/effect/Chebyshev.ts
+++ b/Tone/effect/Chebyshev.ts
@@ -42,14 +42,12 @@ export class Chebyshev extends Effect<ChebyshevOptions> {
 	constructor(order?: Positive);
 	constructor(options?: Partial<ChebyshevOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Chebyshev.getDefaults(), arguments, ["order"])
-		);
 		const options = optionsFromArguments(
 			Chebyshev.getDefaults(),
 			arguments,
 			["order"]
 		);
+		super(options);
 
 		this._shaper = new WaveShaper({
 			context: this.context,

--- a/Tone/effect/Chorus.ts
+++ b/Tone/effect/Chorus.ts
@@ -88,18 +88,12 @@ export class Chorus extends StereoFeedbackEffect<ChorusOptions> {
 	);
 	constructor(options?: Partial<ChorusOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Chorus.getDefaults(), arguments, [
-				"frequency",
-				"delayTime",
-				"depth",
-			])
-		);
 		const options = optionsFromArguments(Chorus.getDefaults(), arguments, [
 			"frequency",
 			"delayTime",
 			"depth",
 		]);
+		super(options);
 
 		this._depth = options.depth;
 		this._delayTime = options.delayTime / 1000;

--- a/Tone/effect/Distortion.ts
+++ b/Tone/effect/Distortion.ts
@@ -36,16 +36,12 @@ export class Distortion extends Effect<DistortionOptions> {
 	constructor(distortion?: number);
 	constructor(options?: Partial<DistortionOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Distortion.getDefaults(), arguments, [
-				"distortion",
-			])
-		);
 		const options = optionsFromArguments(
 			Distortion.getDefaults(),
 			arguments,
 			["distortion"]
 		);
+		super(options);
 
 		this._shaper = new WaveShaper({
 			context: this.context,

--- a/Tone/effect/FeedbackDelay.ts
+++ b/Tone/effect/FeedbackDelay.ts
@@ -40,17 +40,12 @@ export class FeedbackDelay extends FeedbackEffect<FeedbackDelayOptions> {
 	constructor(delayTime?: Time, feedback?: NormalRange);
 	constructor(options?: Partial<FeedbackDelayOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(FeedbackDelay.getDefaults(), arguments, [
-				"delayTime",
-				"feedback",
-			])
-		);
 		const options = optionsFromArguments(
 			FeedbackDelay.getDefaults(),
 			arguments,
 			["delayTime", "feedback"]
 		);
+		super(options);
 
 		this._delayNode = new Delay({
 			context: this.context,

--- a/Tone/effect/Freeverb.ts
+++ b/Tone/effect/Freeverb.ts
@@ -71,17 +71,12 @@ export class Freeverb extends StereoEffect<FreeverbOptions> {
 	constructor(roomSize?: NormalRange, dampening?: Frequency);
 	constructor(options?: Partial<FreeverbOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Freeverb.getDefaults(), arguments, [
-				"roomSize",
-				"dampening",
-			])
-		);
 		const options = optionsFromArguments(
 			Freeverb.getDefaults(),
 			arguments,
 			["roomSize", "dampening"]
 		);
+		super(options);
 
 		this.roomSize = new Signal({
 			context: this.context,

--- a/Tone/effect/FrequencyShifter.ts
+++ b/Tone/effect/FrequencyShifter.ts
@@ -81,16 +81,12 @@ export class FrequencyShifter extends Effect<FrequencyShifterOptions> {
 	constructor(frequency?: Frequency);
 	constructor(options?: Partial<FrequencyShifterOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(FrequencyShifter.getDefaults(), arguments, [
-				"frequency",
-			])
-		);
 		const options = optionsFromArguments(
 			FrequencyShifter.getDefaults(),
 			arguments,
 			["frequency"]
 		);
+		super(options);
 
 		this.frequency = new Signal({
 			context: this.context,

--- a/Tone/effect/JCReverb.ts
+++ b/Tone/effect/JCReverb.ts
@@ -73,16 +73,12 @@ export class JCReverb extends StereoEffect<JCReverbOptions> {
 	constructor(roomSize?: NormalRange);
 	constructor(options?: Partial<JCReverbOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(JCReverb.getDefaults(), arguments, [
-				"roomSize",
-			])
-		);
 		const options = optionsFromArguments(
 			JCReverb.getDefaults(),
 			arguments,
 			["roomSize"]
 		);
+		super(options);
 
 		this.roomSize = new Signal({
 			context: this.context,

--- a/Tone/effect/Phaser.ts
+++ b/Tone/effect/Phaser.ts
@@ -83,18 +83,12 @@ export class Phaser extends StereoEffect<PhaserOptions> {
 	);
 	constructor(options?: Partial<PhaserOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Phaser.getDefaults(), arguments, [
-				"frequency",
-				"octaves",
-				"baseFrequency",
-			])
-		);
 		const options = optionsFromArguments(Phaser.getDefaults(), arguments, [
 			"frequency",
 			"octaves",
 			"baseFrequency",
 		]);
+		super(options);
 
 		this._lfoL = new LFO({
 			context: this.context,

--- a/Tone/effect/PingPongDelay.ts
+++ b/Tone/effect/PingPongDelay.ts
@@ -57,17 +57,12 @@ export class PingPongDelay extends StereoXFeedbackEffect<PingPongDelayOptions> {
 	constructor(delayTime?: Time, feedback?: NormalRange);
 	constructor(options?: Partial<PingPongDelayOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(PingPongDelay.getDefaults(), arguments, [
-				"delayTime",
-				"feedback",
-			])
-		);
 		const options = optionsFromArguments(
 			PingPongDelay.getDefaults(),
 			arguments,
 			["delayTime", "feedback"]
 		);
+		super(options);
 
 		this._leftDelay = new Delay({
 			context: this.context,

--- a/Tone/effect/PitchShift.ts
+++ b/Tone/effect/PitchShift.ts
@@ -88,14 +88,12 @@ export class PitchShift extends FeedbackEffect<PitchShiftOptions> {
 	constructor(pitch?: Interval);
 	constructor(options?: Partial<PitchShiftOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(PitchShift.getDefaults(), arguments, ["pitch"])
-		);
 		const options = optionsFromArguments(
 			PitchShift.getDefaults(),
 			arguments,
 			["pitch"]
 		);
+		super(options);
 
 		this._frequency = new Signal({ context: this.context });
 		this._delayA = new Delay({

--- a/Tone/effect/Reverb.ts
+++ b/Tone/effect/Reverb.ts
@@ -56,10 +56,10 @@ export class Reverb extends Effect<ReverbOptions> {
 	constructor(decay?: Seconds);
 	constructor(options?: Partial<ReverbOptions>);
 	constructor() {
-		super(optionsFromArguments(Reverb.getDefaults(), arguments, ["decay"]));
 		const options = optionsFromArguments(Reverb.getDefaults(), arguments, [
 			"decay",
 		]);
+		super(options);
 
 		this._decay = options.decay;
 		this._preDelay = options.preDelay;

--- a/Tone/effect/StereoWidener.ts
+++ b/Tone/effect/StereoWidener.ts
@@ -63,16 +63,13 @@ export class StereoWidener extends MidSideEffect<StereoWidenerOptions> {
 	constructor(width?: NormalRange);
 	constructor(options?: Partial<StereoWidenerOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(StereoWidener.getDefaults(), arguments, [
-				"width",
-			])
-		);
 		const options = optionsFromArguments(
 			StereoWidener.getDefaults(),
 			arguments,
 			["width"]
 		);
+		super(options);
+
 		this.width = new Signal({
 			context: this.context,
 			value: options.width,

--- a/Tone/effect/Tremolo.ts
+++ b/Tone/effect/Tremolo.ts
@@ -68,16 +68,11 @@ export class Tremolo extends StereoEffect<TremoloOptions> {
 	constructor(frequency?: Frequency, depth?: NormalRange);
 	constructor(options?: Partial<TremoloOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Tremolo.getDefaults(), arguments, [
-				"frequency",
-				"depth",
-			])
-		);
 		const options = optionsFromArguments(Tremolo.getDefaults(), arguments, [
 			"frequency",
 			"depth",
 		]);
+		super(options);
 
 		this._lfoL = new LFO({
 			context: this.context,

--- a/Tone/effect/Vibrato.ts
+++ b/Tone/effect/Vibrato.ts
@@ -48,16 +48,11 @@ export class Vibrato extends Effect<VibratoOptions> {
 	constructor(frequency?: Frequency, depth?: NormalRange);
 	constructor(options?: Partial<VibratoOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Vibrato.getDefaults(), arguments, [
-				"frequency",
-				"depth",
-			])
-		);
 		const options = optionsFromArguments(Vibrato.getDefaults(), arguments, [
 			"frequency",
 			"depth",
 		]);
+		super(options);
 
 		this._delayNode = new Delay({
 			context: this.context,

--- a/Tone/event/Loop.ts
+++ b/Tone/event/Loop.ts
@@ -59,16 +59,11 @@ export class Loop<
 	constructor(callback?: (time: Seconds) => void, interval?: Time);
 	constructor(options?: Partial<LoopOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Loop.getDefaults(), arguments, [
-				"callback",
-				"interval",
-			])
-		);
 		const options = optionsFromArguments(Loop.getDefaults(), arguments, [
 			"callback",
 			"interval",
 		]);
+		super(options);
 
 		this._event = new ToneEvent({
 			context: this.context,

--- a/Tone/event/Part.ts
+++ b/Tone/event/Part.ts
@@ -83,16 +83,11 @@ export class Part<ValueType = any> extends ToneEvent<ValueType> {
 	);
 	constructor(options?: Partial<PartOptions<ValueType>>);
 	constructor() {
-		super(
-			optionsFromArguments(Part.getDefaults(), arguments, [
-				"callback",
-				"events",
-			])
-		);
 		const options = optionsFromArguments(Part.getDefaults(), arguments, [
 			"callback",
 			"events",
 		]);
+		super(options);
 
 		// make sure things are assigned in the right order
 		this._state.increasing = true;

--- a/Tone/event/Pattern.ts
+++ b/Tone/event/Pattern.ts
@@ -65,18 +65,12 @@ export class Pattern<ValueType> extends Loop<PatternOptions<ValueType>> {
 	);
 	constructor(options?: Partial<PatternOptions<ValueType>>);
 	constructor() {
-		super(
-			optionsFromArguments(Pattern.getDefaults(), arguments, [
-				"callback",
-				"values",
-				"pattern",
-			])
-		);
 		const options = optionsFromArguments(Pattern.getDefaults(), arguments, [
 			"callback",
 			"values",
 			"pattern",
 		]);
+		super(options);
 
 		this.callback = options.callback;
 		this._values = options.values;

--- a/Tone/event/Sequence.ts
+++ b/Tone/event/Sequence.ts
@@ -75,18 +75,12 @@ export class Sequence<ValueType = any> extends ToneEvent<ValueType> {
 	);
 	constructor(options?: Partial<SequenceOptions<ValueType>>);
 	constructor() {
-		super(
-			optionsFromArguments(Sequence.getDefaults(), arguments, [
-				"callback",
-				"events",
-				"subdivision",
-			])
-		);
 		const options = optionsFromArguments(
 			Sequence.getDefaults(),
 			arguments,
 			["callback", "events", "subdivision"]
 		);
+		super(options);
 
 		this._subdivision = this.toTicks(options.subdivision);
 

--- a/Tone/event/ToneEvent.ts
+++ b/Tone/event/ToneEvent.ts
@@ -124,17 +124,12 @@ export class ToneEvent<ValueType = any> extends ToneWithContext<
 	constructor(callback?: ToneEventCallback<ValueType>, value?: ValueType);
 	constructor(options?: Partial<ToneEventOptions<ValueType>>);
 	constructor() {
-		super(
-			optionsFromArguments(ToneEvent.getDefaults(), arguments, [
-				"callback",
-				"value",
-			])
-		);
 		const options = optionsFromArguments(
 			ToneEvent.getDefaults(),
 			arguments,
 			["callback", "value"]
 		);
+		super(options);
 
 		this._loop = options.loop;
 		this.callback = options.callback;

--- a/Tone/instrument/DuoSynth.ts
+++ b/Tone/instrument/DuoSynth.ts
@@ -84,8 +84,8 @@ export class DuoSynth extends Monophonic<DuoSynthOptions> {
 
 	constructor(options?: RecursivePartial<DuoSynthOptions>);
 	constructor() {
-		super(optionsFromArguments(DuoSynth.getDefaults(), arguments));
 		const options = optionsFromArguments(DuoSynth.getDefaults(), arguments);
+		super(options);
 
 		this.voice0 = new MonoSynth(
 			Object.assign(options.voice0, {

--- a/Tone/instrument/FMSynth.ts
+++ b/Tone/instrument/FMSynth.ts
@@ -33,8 +33,8 @@ export class FMSynth extends ModulationSynth<FMSynthOptions> {
 
 	constructor(options?: RecursivePartial<FMSynthOptions>);
 	constructor() {
-		super(optionsFromArguments(FMSynth.getDefaults(), arguments));
 		const options = optionsFromArguments(FMSynth.getDefaults(), arguments);
+		super(options);
 
 		this.modulationIndex = new Multiply({
 			context: this.context,

--- a/Tone/instrument/Instrument.ts
+++ b/Tone/instrument/Instrument.ts
@@ -52,11 +52,11 @@ export abstract class Instrument<
 
 	constructor(options?: Partial<InstrumentOptions>);
 	constructor() {
-		super(optionsFromArguments(Instrument.getDefaults(), arguments));
 		const options = optionsFromArguments(
 			Instrument.getDefaults(),
 			arguments
 		);
+		super(options);
 
 		this._volume = this.output = new Volume({
 			context: this.context,

--- a/Tone/instrument/MembraneSynth.ts
+++ b/Tone/instrument/MembraneSynth.ts
@@ -53,11 +53,11 @@ export class MembraneSynth extends Synth<MembraneSynthOptions> {
 	 */
 	constructor(options?: RecursivePartial<MembraneSynthOptions>);
 	constructor() {
-		super(optionsFromArguments(MembraneSynth.getDefaults(), arguments));
 		const options = optionsFromArguments(
 			MembraneSynth.getDefaults(),
 			arguments
 		);
+		super(options);
 
 		this.pitchDecay = options.pitchDecay;
 		this.octaves = options.octaves;

--- a/Tone/instrument/MetalSynth.ts
+++ b/Tone/instrument/MetalSynth.ts
@@ -97,11 +97,11 @@ export class MetalSynth extends Monophonic<MetalSynthOptions> {
 
 	constructor(options?: RecursivePartial<MetalSynthOptions>);
 	constructor() {
-		super(optionsFromArguments(MetalSynth.getDefaults(), arguments));
 		const options = optionsFromArguments(
 			MetalSynth.getDefaults(),
 			arguments
 		);
+		super(options);
 
 		this.detune = new Signal({
 			context: this.context,

--- a/Tone/instrument/ModulationSynth.ts
+++ b/Tone/instrument/ModulationSynth.ts
@@ -88,11 +88,11 @@ export abstract class ModulationSynth<
 
 	constructor(options?: RecursivePartial<ModulationSynthOptions>);
 	constructor() {
-		super(optionsFromArguments(ModulationSynth.getDefaults(), arguments));
 		const options = optionsFromArguments(
 			ModulationSynth.getDefaults(),
 			arguments
 		);
+		super(options);
 
 		this._carrier = new Synth({
 			context: this.context,

--- a/Tone/instrument/MonoSynth.ts
+++ b/Tone/instrument/MonoSynth.ts
@@ -77,11 +77,11 @@ export class MonoSynth extends Monophonic<MonoSynthOptions> {
 
 	constructor(options?: RecursivePartial<MonoSynthOptions>);
 	constructor() {
-		super(optionsFromArguments(MonoSynth.getDefaults(), arguments));
 		const options = optionsFromArguments(
 			MonoSynth.getDefaults(),
 			arguments
 		);
+		super(options);
 
 		this.oscillator = new OmniOscillator(
 			Object.assign(options.oscillator, {

--- a/Tone/instrument/Monophonic.ts
+++ b/Tone/instrument/Monophonic.ts
@@ -49,11 +49,11 @@ export abstract class Monophonic<
 
 	constructor(options?: Partial<MonophonicOptions>);
 	constructor() {
-		super(optionsFromArguments(Monophonic.getDefaults(), arguments));
 		const options = optionsFromArguments(
 			Monophonic.getDefaults(),
 			arguments
 		);
+		super(options);
 
 		this.portamento = options.portamento;
 		this.onsilence = options.onsilence;

--- a/Tone/instrument/NoiseSynth.ts
+++ b/Tone/instrument/NoiseSynth.ts
@@ -43,11 +43,12 @@ export class NoiseSynth extends Instrument<NoiseSynthOptions> {
 
 	constructor(options?: RecursivePartial<NoiseSynthOptions>);
 	constructor() {
-		super(optionsFromArguments(NoiseSynth.getDefaults(), arguments));
 		const options = optionsFromArguments(
 			NoiseSynth.getDefaults(),
 			arguments
 		);
+		super(options);
+
 		this.noise = new Noise(
 			Object.assign(
 				{

--- a/Tone/instrument/PluckSynth.ts
+++ b/Tone/instrument/PluckSynth.ts
@@ -52,11 +52,11 @@ export class PluckSynth extends Instrument<PluckSynthOptions> {
 
 	constructor(options?: RecursivePartial<PluckSynthOptions>);
 	constructor() {
-		super(optionsFromArguments(PluckSynth.getDefaults(), arguments));
 		const options = optionsFromArguments(
 			PluckSynth.getDefaults(),
 			arguments
 		);
+		super(options);
 
 		this._noise = new Noise({
 			context: this.context,

--- a/Tone/instrument/PolySynth.ts
+++ b/Tone/instrument/PolySynth.ts
@@ -137,17 +137,12 @@ export class PolySynth<
 	);
 	constructor(options?: Partial<PolySynthOptions<Voice>>);
 	constructor() {
-		super(
-			optionsFromArguments(PolySynth.getDefaults(), arguments, [
-				"voice",
-				"options",
-			])
-		);
 		const options = optionsFromArguments(
 			PolySynth.getDefaults(),
 			arguments,
 			["voice", "options"]
 		);
+		super(options);
 
 		// check against the old API (pre 14.3.0)
 		assert(

--- a/Tone/instrument/Sampler.ts
+++ b/Tone/instrument/Sampler.ts
@@ -110,20 +110,13 @@ export class Sampler extends Instrument<SamplerOptions> {
 	);
 	constructor(options?: Partial<SamplerOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(
-				Sampler.getDefaults(),
-				arguments,
-				["urls", "onload", "baseUrl"],
-				"urls"
-			)
-		);
 		const options = optionsFromArguments(
 			Sampler.getDefaults(),
 			arguments,
 			["urls", "onload", "baseUrl"],
 			"urls"
 		);
+		super(options);
 
 		const urlMap = {};
 		Object.keys(options.urls).forEach((note) => {

--- a/Tone/instrument/Synth.ts
+++ b/Tone/instrument/Synth.ts
@@ -64,8 +64,8 @@ export class Synth<
 	 */
 	constructor(options?: RecursivePartial<SynthOptions>);
 	constructor() {
-		super(optionsFromArguments(Synth.getDefaults(), arguments));
 		const options = optionsFromArguments(Synth.getDefaults(), arguments);
+		super(options);
 
 		this.oscillator = new OmniOscillator(
 			Object.assign(

--- a/Tone/signal/Add.ts
+++ b/Tone/signal/Add.ts
@@ -43,11 +43,7 @@ export class Add extends Signal {
 	constructor(value?: number);
 	constructor(options?: Partial<SignalOptions<"number">>);
 	constructor() {
-		super(
-			Object.assign(
-				optionsFromArguments(Add.getDefaults(), arguments, ["value"])
-			)
-		);
+		super(optionsFromArguments(Add.getDefaults(), arguments, ["value"]));
 
 		connectSeries(this._constantSource, this._sum);
 	}

--- a/Tone/signal/GreaterThan.ts
+++ b/Tone/signal/GreaterThan.ts
@@ -55,18 +55,12 @@ export class GreaterThan extends Signal<"number"> {
 	constructor(value?: number);
 	constructor(options?: Partial<GreaterThanOptions>);
 	constructor() {
-		super(
-			Object.assign(
-				optionsFromArguments(GreaterThan.getDefaults(), arguments, [
-					"value",
-				])
-			)
-		);
 		const options = optionsFromArguments(
 			GreaterThan.getDefaults(),
 			arguments,
 			["value"]
 		);
+		super(options);
 
 		this._subtract = this.input = new Subtract({
 			context: this.context,

--- a/Tone/signal/GreaterThanZero.ts
+++ b/Tone/signal/GreaterThanZero.ts
@@ -35,11 +35,7 @@ export class GreaterThanZero extends SignalOperator<GreaterThanZeroOptions> {
 
 	constructor(options?: Partial<GreaterThanZeroOptions>);
 	constructor() {
-		super(
-			Object.assign(
-				optionsFromArguments(GreaterThanZero.getDefaults(), arguments)
-			)
-		);
+		super(optionsFromArguments(GreaterThanZero.getDefaults(), arguments));
 
 		this._thresh = this.output = new WaveShaper({
 			context: this.context,

--- a/Tone/signal/Multiply.ts
+++ b/Tone/signal/Multiply.ts
@@ -59,18 +59,12 @@ export class Multiply<
 	constructor(value?: number);
 	constructor(options?: Partial<SignalOptions<TypeName>>);
 	constructor() {
-		super(
-			Object.assign(
-				optionsFromArguments(Multiply.getDefaults(), arguments, [
-					"value",
-				])
-			)
-		);
 		const options = optionsFromArguments(
 			Multiply.getDefaults(),
 			arguments,
 			["value"]
 		);
+		super(options);
 
 		this._mult =
 			this.input =

--- a/Tone/signal/Pow.ts
+++ b/Tone/signal/Pow.ts
@@ -33,14 +33,10 @@ export class Pow extends SignalOperator<PowOptions> {
 	constructor(value?: number);
 	constructor(options?: Partial<PowOptions>);
 	constructor() {
-		super(
-			Object.assign(
-				optionsFromArguments(Pow.getDefaults(), arguments, ["value"])
-			)
-		);
 		const options = optionsFromArguments(Pow.getDefaults(), arguments, [
 			"value",
 		]);
+		super(options);
 
 		this._exponentScaler =
 			this.input =

--- a/Tone/signal/Scale.ts
+++ b/Tone/signal/Scale.ts
@@ -59,18 +59,11 @@ export class Scale<
 	constructor(min?: number, max?: number);
 	constructor(options?: Partial<ScaleOptions>);
 	constructor() {
-		super(
-			Object.assign(
-				optionsFromArguments(Scale.getDefaults(), arguments, [
-					"min",
-					"max",
-				])
-			)
-		);
 		const options = optionsFromArguments(Scale.getDefaults(), arguments, [
 			"min",
 			"max",
 		]);
+		super(options as Options);
 
 		this._mult = this.input = new Multiply({
 			context: this.context,

--- a/Tone/signal/ScaleExp.ts
+++ b/Tone/signal/ScaleExp.ts
@@ -32,20 +32,12 @@ export class ScaleExp extends Scale<ScaleExpOptions> {
 	constructor(min?: number, max?: number, exponent?: number);
 	constructor(options?: Partial<ScaleExpOptions>);
 	constructor() {
-		super(
-			Object.assign(
-				optionsFromArguments(ScaleExp.getDefaults(), arguments, [
-					"min",
-					"max",
-					"exponent",
-				])
-			)
-		);
 		const options = optionsFromArguments(
 			ScaleExp.getDefaults(),
 			arguments,
 			["min", "max", "exponent"]
 		);
+		super(options);
 
 		this.input = this._exp = new Pow({
 			context: this.context,

--- a/Tone/signal/Signal.ts
+++ b/Tone/signal/Signal.ts
@@ -66,17 +66,11 @@ export class Signal<TypeName extends UnitName = "number">
 	constructor(value?: UnitMap[TypeName], units?: TypeName);
 	constructor(options?: Partial<SignalOptions<TypeName>>);
 	constructor() {
-		super(
-			optionsFromArguments(Signal.getDefaults(), arguments, [
-				"value",
-				"units",
-			])
-		);
-
 		const options = optionsFromArguments(Signal.getDefaults(), arguments, [
 			"value",
 			"units",
 		]) as SignalOptions<TypeName>;
+		super(options);
 
 		this.output = this._constantSource = new ToneConstantSource({
 			context: this.context,

--- a/Tone/signal/SignalOperator.ts
+++ b/Tone/signal/SignalOperator.ts
@@ -17,11 +17,9 @@ export abstract class SignalOperator<
 	constructor(options?: Partial<Options>);
 	constructor() {
 		super(
-			Object.assign(
-				optionsFromArguments(SignalOperator.getDefaults(), arguments, [
-					"context",
-				])
-			)
+			optionsFromArguments(SignalOperator.getDefaults(), arguments, [
+				"context",
+			])
 		);
 	}
 

--- a/Tone/signal/Subtract.ts
+++ b/Tone/signal/Subtract.ts
@@ -54,11 +54,7 @@ export class Subtract extends Signal {
 	constructor(options?: Partial<SignalOptions<"number">>);
 	constructor() {
 		super(
-			Object.assign(
-				optionsFromArguments(Subtract.getDefaults(), arguments, [
-					"value",
-				])
-			)
+			optionsFromArguments(Subtract.getDefaults(), arguments, ["value"])
 		);
 
 		connectSeries(this._constantSource, this._neg, this._sum);

--- a/Tone/signal/SyncedSignal.ts
+++ b/Tone/signal/SyncedSignal.ts
@@ -51,16 +51,11 @@ export class SyncedSignal<
 	constructor(value?: UnitMap[TypeName], units?: TypeName);
 	constructor(options?: Partial<SignalOptions<TypeName>>);
 	constructor() {
-		super(
-			optionsFromArguments(Signal.getDefaults(), arguments, [
-				"value",
-				"units",
-			])
-		);
 		const options = optionsFromArguments(Signal.getDefaults(), arguments, [
 			"value",
 			"units",
 		]) as SignalOptions<TypeName>;
+		super(options);
 
 		this._lastVal = options.value;
 		this._synced = this.context.transport.scheduleRepeat(

--- a/Tone/signal/ToneConstantSource.ts
+++ b/Tone/signal/ToneConstantSource.ts
@@ -42,16 +42,12 @@ export class ToneConstantSource<
 	constructor(offset: UnitMap[TypeName]);
 	constructor(options?: Partial<ToneConstantSourceOptions<TypeName>>);
 	constructor() {
-		super(
-			optionsFromArguments(ToneConstantSource.getDefaults(), arguments, [
-				"offset",
-			])
-		);
 		const options = optionsFromArguments(
 			ToneConstantSource.getDefaults(),
 			arguments,
 			["offset"]
 		);
+		super(options);
 
 		connect(this._source, this._gainNode);
 

--- a/Tone/signal/WaveShaper.ts
+++ b/Tone/signal/WaveShaper.ts
@@ -59,19 +59,12 @@ export class WaveShaper extends SignalOperator<WaveShaperOptions> {
 	constructor(mapping?: WaveShaperMapping, length?: number);
 	constructor(options?: Partial<WaveShaperOptions>);
 	constructor() {
-		super(
-			Object.assign(
-				optionsFromArguments(WaveShaper.getDefaults(), arguments, [
-					"mapping",
-					"length",
-				])
-			)
-		);
 		const options = optionsFromArguments(
 			WaveShaper.getDefaults(),
 			arguments,
 			["mapping", "length"]
 		);
+		super(options);
 
 		if (
 			isArray(options.mapping) ||

--- a/Tone/signal/Zero.ts
+++ b/Tone/signal/Zero.ts
@@ -33,9 +33,7 @@ export class Zero extends SignalOperator<ToneAudioNodeOptions> {
 
 	constructor(options?: Partial<ToneAudioNodeOptions>);
 	constructor() {
-		super(
-			Object.assign(optionsFromArguments(Zero.getDefaults(), arguments))
-		);
+		super(optionsFromArguments(Zero.getDefaults(), arguments));
 		connect(this.context.getConstant(0), this._gain);
 	}
 

--- a/Tone/source/Noise.ts
+++ b/Tone/source/Noise.ts
@@ -69,10 +69,10 @@ export class Noise extends Source<NoiseOptions> {
 	constructor(type?: NoiseType);
 	constructor(options?: Partial<NoiseOptions>);
 	constructor() {
-		super(optionsFromArguments(Noise.getDefaults(), arguments, ["type"]));
 		const options = optionsFromArguments(Noise.getDefaults(), arguments, [
 			"type",
 		]);
+		super(options);
 
 		this._playbackRate = options.playbackRate;
 		this.type = options.type;

--- a/Tone/source/UserMedia.ts
+++ b/Tone/source/UserMedia.ts
@@ -73,14 +73,12 @@ export class UserMedia extends ToneAudioNode<UserMediaOptions> {
 	constructor(volume?: Decibels);
 	constructor(options?: Partial<UserMediaOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(UserMedia.getDefaults(), arguments, ["volume"])
-		);
 		const options = optionsFromArguments(
 			UserMedia.getDefaults(),
 			arguments,
 			["volume"]
 		);
+		super(options);
 
 		this._volume = this.output = new Volume({
 			context: this.context,

--- a/Tone/source/buffer/GrainPlayer.ts
+++ b/Tone/source/buffer/GrainPlayer.ts
@@ -92,17 +92,12 @@ export class GrainPlayer extends Source<GrainPlayerOptions> {
 	);
 	constructor(options?: Partial<GrainPlayerOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(GrainPlayer.getDefaults(), arguments, [
-				"url",
-				"onload",
-			])
-		);
 		const options = optionsFromArguments(
 			GrainPlayer.getDefaults(),
 			arguments,
 			["url", "onload"]
 		);
+		super(options);
 
 		this.buffer = new ToneAudioBuffer({
 			onload: options.onload,

--- a/Tone/source/buffer/Player.ts
+++ b/Tone/source/buffer/Player.ts
@@ -91,16 +91,11 @@ export class Player extends Source<PlayerOptions> {
 	);
 	constructor(options?: Partial<PlayerOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Player.getDefaults(), arguments, [
-				"url",
-				"onload",
-			])
-		);
 		const options = optionsFromArguments(Player.getDefaults(), arguments, [
 			"url",
 			"onload",
 		]);
+		super(options);
 
 		this._buffer = new ToneAudioBuffer({
 			onload: this._onload.bind(this, options.onload),

--- a/Tone/source/buffer/Players.ts
+++ b/Tone/source/buffer/Players.ts
@@ -87,20 +87,13 @@ export class Players extends ToneAudioNode<PlayersOptions> {
 	);
 	constructor(options?: Partial<PlayersOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(
-				Players.getDefaults(),
-				arguments,
-				["urls", "onload"],
-				"urls"
-			)
-		);
 		const options = optionsFromArguments(
 			Players.getDefaults(),
 			arguments,
 			["urls", "onload"],
 			"urls"
 		);
+		super(options);
 
 		/**
 		 * The output volume node

--- a/Tone/source/buffer/ToneBufferSource.ts
+++ b/Tone/source/buffer/ToneBufferSource.ts
@@ -67,17 +67,12 @@ export class ToneBufferSource extends OneShotSource<ToneBufferSourceOptions> {
 	);
 	constructor(options?: Partial<ToneBufferSourceOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(ToneBufferSource.getDefaults(), arguments, [
-				"url",
-				"onload",
-			])
-		);
 		const options = optionsFromArguments(
 			ToneBufferSource.getDefaults(),
 			arguments,
 			["url", "onload"]
 		);
+		super(options);
 
 		connect(this._source, this._gainNode);
 		this._source.onended = () => this._stopSource();

--- a/Tone/source/oscillator/AMOscillator.ts
+++ b/Tone/source/oscillator/AMOscillator.ts
@@ -97,18 +97,12 @@ export class AMOscillator
 	);
 	constructor(options?: Partial<AMConstructorOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(AMOscillator.getDefaults(), arguments, [
-				"frequency",
-				"type",
-				"modulationType",
-			])
-		);
 		const options = optionsFromArguments(
 			AMOscillator.getDefaults(),
 			arguments,
 			["frequency", "type", "modulationType"]
 		);
+		super(options);
 
 		this._carrier = new Oscillator({
 			context: this.context,

--- a/Tone/source/oscillator/FMOscillator.ts
+++ b/Tone/source/oscillator/FMOscillator.ts
@@ -99,18 +99,12 @@ export class FMOscillator
 	);
 	constructor(options?: Partial<FMConstructorOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(FMOscillator.getDefaults(), arguments, [
-				"frequency",
-				"type",
-				"modulationType",
-			])
-		);
 		const options = optionsFromArguments(
 			FMOscillator.getDefaults(),
 			arguments,
 			["frequency", "type", "modulationType"]
 		);
+		super(options);
 
 		this._carrier = new Oscillator({
 			context: this.context,

--- a/Tone/source/oscillator/FatOscillator.ts
+++ b/Tone/source/oscillator/FatOscillator.ts
@@ -79,18 +79,12 @@ export class FatOscillator
 	);
 	constructor(options?: Partial<FatConstructorOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(FatOscillator.getDefaults(), arguments, [
-				"frequency",
-				"type",
-				"spread",
-			])
-		);
 		const options = optionsFromArguments(
 			FatOscillator.getDefaults(),
 			arguments,
 			["frequency", "type", "spread"]
 		);
+		super(options);
 
 		this.frequency = new Signal({
 			context: this.context,

--- a/Tone/source/oscillator/LFO.ts
+++ b/Tone/source/oscillator/LFO.ts
@@ -124,18 +124,12 @@ export class LFO extends ToneAudioNode<LFOOptions> {
 	constructor(frequency?: Frequency, min?: number, max?: number);
 	constructor(options?: Partial<LFOOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(LFO.getDefaults(), arguments, [
-				"frequency",
-				"min",
-				"max",
-			])
-		);
 		const options = optionsFromArguments(LFO.getDefaults(), arguments, [
 			"frequency",
 			"min",
 			"max",
 		]);
+		super(options);
 
 		this._oscillator = new Oscillator(
 			options as ToneOscillatorConstructorOptions

--- a/Tone/source/oscillator/OmniOscillator.ts
+++ b/Tone/source/oscillator/OmniOscillator.ts
@@ -114,17 +114,12 @@ export class OmniOscillator<OscType extends AnyOscillator>
 	constructor(frequency?: Frequency, type?: OmniOscillatorType);
 	constructor(options?: Partial<OmniOscillatorOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(OmniOscillator.getDefaults(), arguments, [
-				"frequency",
-				"type",
-			])
-		);
 		const options = optionsFromArguments(
 			OmniOscillator.getDefaults(),
 			arguments,
 			["frequency", "type"]
 		);
+		super(options);
 
 		this.frequency = new Signal({
 			context: this.context,

--- a/Tone/source/oscillator/Oscillator.ts
+++ b/Tone/source/oscillator/Oscillator.ts
@@ -87,17 +87,12 @@ export class Oscillator
 	constructor(frequency?: Frequency, type?: ToneOscillatorType);
 	constructor(options?: Partial<ToneOscillatorConstructorOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(Oscillator.getDefaults(), arguments, [
-				"frequency",
-				"type",
-			])
-		);
 		const options = optionsFromArguments(
 			Oscillator.getDefaults(),
 			arguments,
 			["frequency", "type"]
 		);
+		super(options);
 
 		this.frequency = new Signal<"frequency">({
 			context: this.context,

--- a/Tone/source/oscillator/PWMOscillator.ts
+++ b/Tone/source/oscillator/PWMOscillator.ts
@@ -77,17 +77,12 @@ export class PWMOscillator
 	constructor(frequency?: Frequency, modulationFrequency?: Frequency);
 	constructor(options?: Partial<PWMOscillatorOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(PWMOscillator.getDefaults(), arguments, [
-				"frequency",
-				"modulationFrequency",
-			])
-		);
 		const options = optionsFromArguments(
 			PWMOscillator.getDefaults(),
 			arguments,
 			["frequency", "modulationFrequency"]
 		);
+		super(options);
 
 		this._pulse = new PulseOscillator({
 			context: this.context,

--- a/Tone/source/oscillator/PulseOscillator.ts
+++ b/Tone/source/oscillator/PulseOscillator.ts
@@ -108,17 +108,12 @@ export class PulseOscillator
 	constructor(frequency?: Frequency, width?: AudioRange);
 	constructor(options?: Partial<PulseOscillatorOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(PulseOscillator.getDefaults(), arguments, [
-				"frequency",
-				"width",
-			])
-		);
 		const options = optionsFromArguments(
 			PulseOscillator.getDefaults(),
 			arguments,
 			["frequency", "width"]
 		);
+		super(options);
 
 		this.width = new Signal({
 			context: this.context,

--- a/Tone/source/oscillator/ToneOscillatorNode.ts
+++ b/Tone/source/oscillator/ToneOscillatorNode.ts
@@ -43,17 +43,12 @@ export class ToneOscillatorNode extends OneShotSource<ToneOscillatorNodeOptions>
 	constructor(frequency: Frequency, type: OscillatorType);
 	constructor(options?: Partial<ToneOscillatorNodeOptions>);
 	constructor() {
-		super(
-			optionsFromArguments(ToneOscillatorNode.getDefaults(), arguments, [
-				"frequency",
-				"type",
-			])
-		);
 		const options = optionsFromArguments(
 			ToneOscillatorNode.getDefaults(),
 			arguments,
 			["frequency", "type"]
 		);
+		super(options);
 
 		connect(this._oscillator, this._gainNode);
 


### PR DESCRIPTION
Re-arranging initialization in most cases to avoid two calls to `optionsFromArguments`