### PR TITLE
Export remaining effect option interfaces

### DIFF
--- a/Tone/effect/FeedbackDelay.ts
+++ b/Tone/effect/FeedbackDelay.ts
@@ -5,7 +5,7 @@ import { optionsFromArguments } from "../core/util/Defaults.js";
 import { readOnly } from "../core/util/Interface.js";
 import { FeedbackEffect, FeedbackEffectOptions } from "./FeedbackEffect.js";
 
-interface FeedbackDelayOptions extends FeedbackEffectOptions {
+export interface FeedbackDelayOptions extends FeedbackEffectOptions {
 	delayTime: Time;
 	maxDelay: Time;
 }

--- a/Tone/effect/FrequencyShifter.ts
+++ b/Tone/effect/FrequencyShifter.ts
@@ -9,7 +9,7 @@ import { Signal } from "../signal/Signal.js";
 import { Oscillator } from "../source/oscillator/Oscillator.js";
 import { ToneOscillatorNode } from "../source/oscillator/ToneOscillatorNode.js";
 
-interface FrequencyShifterOptions extends EffectOptions {
+export interface FrequencyShifterOptions extends EffectOptions {
 	frequency: Frequency;
 }
 

--- a/Tone/effect/Reverb.ts
+++ b/Tone/effect/Reverb.ts
@@ -8,7 +8,7 @@ import { OfflineContext } from "../core/context/OfflineContext.js";
 import { noOp } from "../core/util/Interface.js";
 import { assertRange } from "../core/util/Debug.js";
 
-interface ReverbOptions extends EffectOptions {
+export interface ReverbOptions extends EffectOptions {
 	decay: Seconds;
 	preDelay: Seconds;
 }


### PR DESCRIPTION
The effect option interfaces of FeedbackDelay, FrequenceyShifter and Reverb (FeedbackDelayOptions, FrequencyShifterOptions and ReverbOptions) were not exported unlike all other effect option interfaces.
This PR fixes this discrepancy.