### PR TITLE
Support external AudioWorklets

### DIFF
--- a/Tone/core/worklet/ToneAudioWorklet.ts
+++ b/Tone/core/worklet/ToneAudioWorklet.ts
@@ -59,7 +59,15 @@ export abstract class ToneAudioWorklet<
 		this._dummyParam = this._dummyGain.gain;
 
 		// Register the processor
-		this.context.addAudioWorkletModule(blobUrl).then(() => {
+		let workletPromise = ToneAudioWorklet._workletPromises.get(this.context);
+
+		if (workletPromise === undefined) {
+			workletPromise = this.context.addAudioWorkletModule(blobUrl);
+
+			ToneAudioWorklet._workletPromises.set(this.context, workletPromise);
+		}
+
+		workletPromise.then(() => {
 			// create the worklet when it's read
 			if (!this.disposed) {
 				this._worklet = this.context.createAudioWorkletNode(
@@ -72,6 +80,8 @@ export abstract class ToneAudioWorklet<
 			}
 		});
 	}
+
+	private static _workletPromises = new WeakMap<any, Promise<void>>();
 
 	dispose(): this {
 		super.dispose();


### PR DESCRIPTION
This PR is intended to fix https://github.com/Tonejs/Tone.js/issues/1326. It may also help with https://github.com/Tonejs/Tone.js/issues/1138.

The changes introduced in https://github.com/Tonejs/Tone.js/issues/1038 made it impossible to make Tone load any other `AudioWorklet` except for the ones build-in at least when using `addAudioWorkletModule()`.

To solve this the internal promise is now cached as a static variable on the `ToneAudioWorklet` class.