### PR TITLE
Context.setTimeout try/finally

### DIFF
--- a/Tone/core/context/Context.ts
+++ b/Tone/core/context/Context.ts
@@ -373,7 +373,9 @@ export class Context extends BaseContext {
 		const workletPromise = this.rawContext.audioWorklet.addModule(url);
 
 		this._workletPromises.add(workletPromise);
-		workletPromise.finally(() => this._workletPromises.delete(workletPromise));
+		workletPromise.finally(() =>
+			this._workletPromises.delete(workletPromise)
+		);
 
 		return workletPromise;
 	}
@@ -561,9 +563,11 @@ export class Context extends BaseContext {
 	private _timeoutLoop(): void {
 		const now = this.now();
 		this._timeouts.forEachBefore(now, (event) => {
-			// invoke the callback
-			event.callback();
-			this._timeouts.remove(event);
+			try {
+				event.callback();
+			} finally {
+				this._timeouts.remove(event);
+			}
 		});
 	}
 


### PR DESCRIPTION
Wraps Context.setTimeout callback in try/finally so that the event is still removed even in event of error with the callback method. Previously if an error was thrown within the Context.setTimeout callback, the error callback would repeat infinitely since the event was never removed from the callback queue after the execution was interrupted. 