### PR TITLE
Fix incorrect instances of its and it's

### DIFF
--- a/Tone/component/dynamics/Limiter.ts
+++ b/Tone/component/dynamics/Limiter.ts
@@ -16,7 +16,7 @@ export interface LimiterOptions extends ToneAudioNodeOptions {
 
 /**
  * Limiter will limit the loudness of an incoming signal.
- * Under the hood it's composed of a {@link Compressor} with a fast attack
+ * Under the hood its composed of a {@link Compressor} with a fast attack
  * and release and max compression ratio.
  *
  * @example

--- a/Tone/component/envelope/AmplitudeEnvelope.ts
+++ b/Tone/component/envelope/AmplitudeEnvelope.ts
@@ -36,7 +36,7 @@ export class AmplitudeEnvelope extends Envelope {
 	input: Gain = this._gainNode;
 
 	/**
-	 * @param attack The amount of time it takes for the envelope to go from 0 to it's maximum value.
+	 * @param attack The amount of time it takes for the envelope to go from 0 to its maximum value.
 	 * @param decay	The period of time after the attack that it takes for the envelope
 	 *                      	to fall to the sustain value. Value must be greater than 0.
 	 * @param sustain	The percent of the maximum value that the envelope rests at until

--- a/Tone/component/envelope/Envelope.ts
+++ b/Tone/component/envelope/Envelope.ts
@@ -57,7 +57,7 @@ export class Envelope extends ToneAudioNode<EnvelopeOptions> {
 
 	/**
 	 * When triggerAttack is called, the attack time is the amount of
-	 * time it takes for the envelope to reach it's maximum value.
+	 * time it takes for the envelope to reach its maximum value.
 	 * ```
 	 *           /\
 	 *          /X \
@@ -77,7 +77,7 @@ export class Envelope extends ToneAudioNode<EnvelopeOptions> {
 
 	/**
 	 * After the attack portion of the envelope, the value will fall
-	 * over the duration of the decay time to it's sustain value.
+	 * over the duration of the decay time to its sustain value.
 	 * ```
 	 *           /\
 	 *          / X\
@@ -170,7 +170,7 @@ export class Envelope extends ToneAudioNode<EnvelopeOptions> {
 
 	/**
 	 * @param attack The amount of time it takes for the envelope to go from
-	 *                        0 to it's maximum value.
+	 *                        0 to its maximum value.
 	 * @param decay	The period of time after the attack that it takes for the envelope
 	 *                      	to fall to the sustain value. Value must be greater than 0.
 	 * @param sustain	The percent of the maximum value that the envelope rests at until

--- a/Tone/core/clock/Clock.test.ts
+++ b/Tone/core/clock/Clock.test.ts
@@ -34,7 +34,7 @@ describe("Clock", () => {
 			expect(clock.frequency.value).to.equal(8);
 		});
 
-		it("can get and set it's values with the set/get", () => {
+		it("can get and set its values with the set/get", () => {
 			const clock = new Clock();
 			clock.set({
 				frequency: 2,

--- a/Tone/core/context/AbstractParam.ts
+++ b/Tone/core/context/AbstractParam.ts
@@ -87,7 +87,7 @@ export abstract class AbstractParam<TypeName extends UnitName> {
 	 * duration of the rampTime.
 	 * @param value   The value to ramp to.
 	 * @param rampTime the time that it takes the
-	 *                             value to ramp from it's current value
+	 *                             value to ramp from its current value
 	 * @param startTime When the ramp should start.
 	 * @example
 	 * const delay = new Tone.FeedbackDelay(0.5, 0.98).toDestination();
@@ -114,7 +114,7 @@ export abstract class AbstractParam<TypeName extends UnitName> {
 	 *
 	 * @param  value   The value to ramp to.
 	 * @param  rampTime the time that it takes the
-	 *                              value to ramp from it's current value
+	 *                              value to ramp from its current value
 	 * @param startTime 	When the ramp should start.
 	 * @returns {Param} this
 	 * @example
@@ -141,7 +141,7 @@ export abstract class AbstractParam<TypeName extends UnitName> {
 	 * rampTime is the time that it takes to reach over 99% of the way towards the value.
 	 * @param  value   The value to ramp to.
 	 * @param  rampTime the time that it takes the
-	 *                              value to ramp from it's current value
+	 *                              value to ramp from its current value
 	 * @param startTime 	When the ramp should start.
 	 * @example
 	 * @example
@@ -163,7 +163,7 @@ export abstract class AbstractParam<TypeName extends UnitName> {
 	 * is similar to setTargetAtTime except the third argument is a time instead of a 'timeConstant'
 	 * @param  value   The value to ramp to.
 	 * @param time 	When the ramp should start.
-	 * @param  rampTime the time that it takes the value to ramp from it's current value
+	 * @param  rampTime the time that it takes the value to ramp from its current value
 	 * @example
 	 * const osc = new Tone.Oscillator().toDestination().start();
 	 * // exponential approach over 4 seconds starting in 1 second
@@ -243,7 +243,7 @@ export abstract class AbstractParam<TypeName extends UnitName> {
 	 * depending on the `units` of the signal
 	 *
 	 * @param  value
-	 * @param  rampTime The time that it takes the value to ramp from it's current value
+	 * @param  rampTime The time that it takes the value to ramp from its current value
 	 * @param startTime When the ramp should start.
 	 * @example
 	 * const osc = new Tone.Oscillator().toDestination().start();

--- a/Tone/core/context/ToneAudioBuffer.ts
+++ b/Tone/core/context/ToneAudioBuffer.ts
@@ -103,7 +103,7 @@ export class ToneAudioBuffer extends Tone {
 			if (buffer.loaded) {
 				this._buffer = buffer.get();
 			} else {
-				// otherwise when it's loaded, invoke it's callback
+				// otherwise when its loaded, invoke it's callback
 				buffer.onload = () => {
 					this.set(buffer);
 					this.onload(this);

--- a/Tone/core/util/IntervalTimeline.ts
+++ b/Tone/core/util/IntervalTimeline.ts
@@ -470,7 +470,7 @@ class IntervalNode {
 	}
 
 	/**
-	 * Invoke the callback on this element and both it's branches
+	 * Invoke the callback on this element and both its branches
 	 * @param  {Function}  callback
 	 */
 	traverse(callback: (self: IntervalNode) => void): void {

--- a/Tone/core/worklet/ToneAudioWorkletProcessor.worklet.ts
+++ b/Tone/core/worklet/ToneAudioWorkletProcessor.worklet.ts
@@ -10,7 +10,7 @@ const toneAudioWorkletProcessor = /* javascript */ `
 			
 			super(options);
 			/**
-			 * If the processor was disposed or not. Keep alive until it's disposed.
+			 * If the processor was disposed or not. Keep alive until its disposed.
 			 */
 			this.disposed = false;
 		   	/** 

--- a/Tone/effect/AutoFilter.ts
+++ b/Tone/effect/AutoFilter.ts
@@ -19,7 +19,7 @@ export interface AutoFilterOptions extends LFOEffectOptions {
  * and depth.
  *
  * @example
- * // create an autofilter and start it's LFO
+ * // create an autofilter and start its LFO
  * const autoFilter = new Tone.AutoFilter("4n").toDestination().start();
  * // route an oscillator through the filter and start it
  * const oscillator = new Tone.Oscillator().connect(autoFilter).start();

--- a/Tone/effect/Tremolo.ts
+++ b/Tone/effect/Tremolo.ts
@@ -19,7 +19,7 @@ export interface TremoloOptions extends StereoEffectOptions {
  * The effect is a stereo effect where the modulation phase is inverted in each channel.
  *
  * @example
- * // create a tremolo and start it's LFO
+ * // create a tremolo and start its LFO
  * const tremolo = new Tone.Tremolo(9, 0.75).toDestination().start();
  * // route an oscillator through the tremolo and start it
  * const oscillator = new Tone.Oscillator().connect(tremolo).start();

--- a/Tone/instrument/Sampler.test.ts
+++ b/Tone/instrument/Sampler.test.ts
@@ -267,7 +267,7 @@ describe("Sampler", () => {
 	});
 
 	context("add samples", () => {
-		it("can add a note with it's midi value", async () => {
+		it("can add a note with its midi value", async () => {
 			const buffer = await Offline(() => {
 				const sampler = new Sampler().toDestination();
 				sampler.add(69, A4_buffer);
@@ -276,7 +276,7 @@ describe("Sampler", () => {
 			expect(buffer.isSilent()).to.be.false;
 		});
 
-		it("can add a note with it's note name", async () => {
+		it("can add a note with its note name", async () => {
 			const buffer = await Offline(() => {
 				const sampler = new Sampler().toDestination();
 				sampler.add("A4", A4_buffer);

--- a/Tone/signal/Zero.ts
+++ b/Tone/signal/Zero.ts
@@ -9,7 +9,7 @@ import { SignalOperator } from "./SignalOperator.js";
 
 /**
  * Tone.Zero outputs 0's at audio-rate. The reason this has to be
- * it's own class is that many browsers optimize out Tone.Signal
+ * its own class is that many browsers optimize out Tone.Signal
  * with a value of 0 and will not process nodes further down the graph.
  * @category Signal
  */

--- a/Tone/source/Source.ts
+++ b/Tone/source/Source.ts
@@ -83,7 +83,7 @@ export abstract class Source<
 		offset?: Seconds;
 		/**
 		 * Either the buffer is explicitly scheduled to end using the stop method,
-		 * or it's implicitly ended when the buffer is over.
+		 * or its implicitly ended when the buffer is over.
 		 */
 		implicitEnd?: boolean;
 	}> = new StateTimeline("stopped");

--- a/Tone/source/buffer/Player.ts
+++ b/Tone/source/buffer/Player.ts
@@ -45,7 +45,7 @@ export class Player extends Source<PlayerOptions> {
 	private _buffer: ToneAudioBuffer;
 
 	/**
-	 * if the buffer should loop once it's over
+	 * if the buffer should loop once its over
 	 */
 	private _loop: boolean;
 
@@ -369,7 +369,7 @@ export class Player extends Source<PlayerOptions> {
 	}
 
 	/**
-	 * If the buffer should loop once it's over.
+	 * If the buffer should loop once its over.
 	 * @example
 	 * const player = new Tone.Player("https://tonejs.github.io/audio/drum-samples/breakbeat.mp3").toDestination();
 	 * player.loop = true;

--- a/Tone/source/buffer/ToneBufferSource.ts
+++ b/Tone/source/buffer/ToneBufferSource.ts
@@ -248,7 +248,7 @@ export class ToneBufferSource extends OneShotSource<ToneBufferSourceOptions> {
 	}
 
 	/**
-	 * If the buffer should loop once it's over.
+	 * If the buffer should loop once its over.
 	 */
 	get loop(): boolean {
 		return this._source.loop;

--- a/Tone/source/oscillator/LFO.test.ts
+++ b/Tone/source/oscillator/LFO.test.ts
@@ -85,7 +85,7 @@ describe("LFO", () => {
 			expect(buffer.max()).to.be.lte(18);
 		});
 
-		it("initially outputs a signal at the center of it's phase", async () => {
+		it("initially outputs a signal at the center of its phase", async () => {
 			const buffer = await Offline(() => {
 				new LFO(100, 10, 20).toDestination();
 			});

--- a/Tone/source/oscillator/LFO.ts
+++ b/Tone/source/oscillator/LFO.ts
@@ -76,7 +76,7 @@ export class LFO extends ToneAudioNode<LFOOptions> {
 	private _zeros: Zero;
 
 	/**
-	 * The value that the LFO outputs when it's stopped
+	 * The value that the LFO outputs when its stopped
 	 */
 	private _stoppedValue = 0;
 

--- a/Tone/source/oscillator/PWMOscillator.test.ts
+++ b/Tone/source/oscillator/PWMOscillator.test.ts
@@ -39,7 +39,7 @@ describe("PWMOscillator", () => {
 	});
 
 	context("Types", () => {
-		it("reports it's type", () => {
+		it("reports its type", () => {
 			const osc = new PWMOscillator();
 			expect(osc.type).to.equal("pwm");
 			expect(osc.baseType).to.equal("pwm");

--- a/Tone/source/oscillator/PulseOscillator.test.ts
+++ b/Tone/source/oscillator/PulseOscillator.test.ts
@@ -112,7 +112,7 @@ describe("PulseOscillator", () => {
 	});
 
 	context("Types", () => {
-		it("reports it's type", () => {
+		it("reports its type", () => {
 			const osc = new PulseOscillator();
 			expect(osc.type).to.equal("pulse");
 			expect(osc.baseType).to.equal("pulse");

--- a/test/helper/Basic.ts
+++ b/test/helper/Basic.ts
@@ -25,7 +25,7 @@ export function BasicTests(Constr, ...args: any[]): void {
 			instance.dispose();
 			// check that all of the attributes were disposed
 			expect(instance.disposed).to.equal(true);
-			// also check all of it's attributes to see if they also have the right context
+			// also check all of its attributes to see if they also have the right context
 			for (const member in instance) {
 				if (instance[member] instanceof Tone && member !== "context") {
 					expect(
@@ -59,7 +59,7 @@ export function BasicTests(Constr, ...args: any[]): void {
 			);
 			if (instance instanceof ToneWithContext) {
 				expect(instance.context).to.equal(testAudioContext);
-				// also check all of it's attributes to see if they also have the right context
+				// also check all of its attributes to see if they also have the right context
 				for (const member in instance) {
 					if (instance[member] instanceof ToneWithContext) {
 						expect(


### PR DESCRIPTION
This commit corrects various instances of "its" and "it's" in comments and test names throughout the codebase to ensure proper grammar and clarity.

Tried out using jules.google to find and replace all bad instances, worked pretty well!