### PR TITLE
Support sampleRate option for realtime AudioContext

### DIFF
--- a/Tone/core/context/Context.test.ts
+++ b/Tone/core/context/Context.test.ts
@@ -74,11 +74,13 @@ describe("Context", () => {
 				latencyHint: "playback",
 				lookAhead: 0.2,
 				updateInterval: 0.1,
+				sampleRate: 32000,
 			});
 			expect(ctx.lookAhead).to.equal(0.2);
 			expect(ctx.updateInterval).to.equal(0.1);
 			expect(ctx.latencyHint).to.equal("playback");
 			expect(ctx.clockSource).to.equal("timeout");
+			expect(ctx.sampleRate).to.equal(32000);
 			ctx.dispose();
 			return ctx.close();
 		});

--- a/Tone/core/context/Context.ts
+++ b/Tone/core/context/Context.ts
@@ -23,6 +23,7 @@ export interface ContextOptions {
 	lookAhead: Seconds;
 	updateInterval: Seconds;
 	context: AnyAudioContext;
+	sampleRate: number;
 }
 
 export interface ContextTimeoutEvent {
@@ -116,7 +117,10 @@ export class Context extends BaseContext {
 			// custom context provided, latencyHint unknown (unless explicitly provided in options)
 			this._latencyHint = arguments[0]?.latencyHint || "";
 		} else {
-			this._context = createAudioContext({
+			this._context = createAudioContext(options.sampleRate ? {
+				latencyHint: options.latencyHint,
+				sampleRate: options.sampleRate,
+			} : {
 				latencyHint: options.latencyHint,
 			});
 			this._latencyHint = options.latencyHint;


### PR DESCRIPTION
This PR is intended to fix #1023. It's adding the possibility to set the `sampleRate` when creating a new realtime `AudioContext`.

Does the documentation update automatically?

Should `sampleRate` better be of type `Frequency` instead of being a simple `number`?
