### PR TITLE
Issue #1354 fix - 'MembraneSynth' 

### DIFF
--- a/Tone/instrument/MembraneSynth.test.ts
+++ b/Tone/instrument/MembraneSynth.test.ts
@@ -52,12 +52,42 @@ describe("MembraneSynth", () => {
 
 		it("can get and set the octaves and pitch decay", () => {
 			const drumSynth = new MembraneSynth();
-			drumSynth.octaves = 12;
+			drumSynth.octaves = 8;
 			drumSynth.pitchDecay = 0.2;
 			expect(drumSynth.pitchDecay).to.equal(0.2);
-			expect(drumSynth.octaves).to.equal(12);
+			expect(drumSynth.octaves).to.equal(8);
 			drumSynth.dispose();
 		});
+
+		it("validates octaves range", () => {
+			const drumSynth = new MembraneSynth();
+			// Test minimum boundary
+			drumSynth.octaves = 0.5;
+			expect(drumSynth.octaves).to.equal(0.5);
+			// Test maximum boundary
+			drumSynth.octaves = 8;
+			expect(drumSynth.octaves).to.equal(8);
+			drumSynth.dispose();
+		});
+
+		it("validates pitchDecay range", () => {
+			const drumSynth = new MembraneSynth();
+			drumSynth.pitchDecay = 0;
+			expect(drumSynth.pitchDecay).to.equal(0);
+			drumSynth.pitchDecay = 0.5;
+			expect(drumSynth.pitchDecay).to.equal(0.5);
+			drumSynth.dispose();
+		});
+
+		it("Finds correct maximum note frequency", () => {
+			const drumSynth = new MembraneSynth();
+			const hertz = 65.4; // C2 
+			drumSynth.octaves = 8;
+			const maxNote = hertz * Math.pow(2, drumSynth.octaves); 
+			expect(maxNote).to.equal(16742.4); // C2 + 8 octaves 
+			drumSynth.dispose();
+		});
+
 
 		it("can be constructed with an options object", () => {
 			const drumSynth = new MembraneSynth({

--- a/Tone/instrument/MembraneSynth.ts
+++ b/Tone/instrument/MembraneSynth.ts
@@ -32,7 +32,7 @@ export class MembraneSynth extends Synth<MembraneSynthOptions> {
 	 * @min 0.5
 	 * @max 8
 	 */
-	@range(0)
+	@range(0.5, 8)
 	octaves: Positive;
 
 	/**
@@ -40,7 +40,7 @@ export class MembraneSynth extends Synth<MembraneSynthOptions> {
 	 * @min 0
 	 * @max 0.5
 	 */
-	@timeRange(0)
+	@timeRange(0, 0.5)
 	pitchDecay: Time;
 
 	/**
@@ -73,7 +73,7 @@ export class MembraneSynth extends Synth<MembraneSynthOptions> {
 				release: 1.4,
 				sustain: 0.01,
 			},
-			octaves: 10,
+			octaves: 8,
 			oscillator: {
 				type: "sine",
 			},
@@ -86,7 +86,7 @@ export class MembraneSynth extends Synth<MembraneSynthOptions> {
 		const hertz = this.toFrequency(
 			note instanceof FrequencyClass ? note.toFrequency() : note
 		);
-		const maxNote = hertz * this.octaves;
+		const maxNote = hertz * Math.pow(2, this.octaves);
 		this.oscillator.frequency.setValueAtTime(maxNote, seconds);
 		this.oscillator.frequency.exponentialRampToValueAtTime(
 			hertz,


### PR DESCRIPTION
Issue link: (https://github.com/Tonejs/Tone.js/issues/1354#issue-3159829067)

Correct octave default value to match documentation.
Add range values for octaves and pitch decay timeRange to match documentation.
Update maxNote equation to increase in full octaves.
Add update or add tests for the above changes.