### PR TITLE
fix: setting seconds fails with certain times

### DIFF
--- a/Tone/core/clock/Transport.test.ts
+++ b/Tone/core/clock/Transport.test.ts
@@ -316,6 +316,22 @@ describe("Transport", () => {
 			}, 0.2);
 			expect(wasCalled).to.be.true;
 		});
+
+		it("setting the same ticks value twice does not emit twice", async () => {
+			await Offline(({ transport }) => {
+				let callCount = 0;
+				transport.on("ticks", () => {
+					callCount++;
+				});
+				transport.ticks = 100;
+				expect(transport.ticks).to.equal(100);
+				expect(callCount).to.equal(1);
+
+				// set it to the same value again has no change
+				transport.ticks = 100;
+				expect(callCount).to.equal(1);
+			}, 0.1);
+		});
 	});
 
 	context("state", () => {

--- a/Tone/core/clock/Transport.test.ts
+++ b/Tone/core/clock/Transport.test.ts
@@ -303,7 +303,7 @@ describe("Transport", () => {
 			}, 0.2);
 		});
 
-		it("invokes the first callback time when the scheduled time is the same as the start time", async () => {
+		it("invokes the first callback time when the scheduled time is a non-integer tick time", async () => {
 			let wasCalled = false;
 			await Offline(({ transport }) => {
 				// choose a value which is not cleanly representable as ticks

--- a/Tone/core/clock/Transport.test.ts
+++ b/Tone/core/clock/Transport.test.ts
@@ -302,6 +302,20 @@ describe("Transport", () => {
 				});
 			}, 0.2);
 		});
+
+		it("invokes the first callback time when the scheduled time is the same as the start time", async () => {
+			let wasCalled = false;
+			await Offline(({ transport }) => {
+				// choose a value which is not cleanly representable as ticks
+				const problemValue = Time(100, "i").toSeconds() + 0.01;
+				transport.seconds = problemValue;
+				transport.schedule(() => {
+					wasCalled = true;
+				}, problemValue);
+				transport.start();
+			}, 0.2);
+			expect(wasCalled).to.be.true;
+		});
 	});
 
 	context("state", () => {

--- a/Tone/core/clock/Transport.ts
+++ b/Tone/core/clock/Transport.ts
@@ -625,25 +625,30 @@ export class TransportInstance
 	}
 	set ticks(t: Ticks) {
 		assertUsedScheduleTime();
-		if (this._clock.ticks !== t) {
-			const now = this.now();
-			// stop everything synced to the transport
-			if (this.state === "started") {
-				const ticks = this._clock.getTicksAtTime(now);
-				// schedule to start on the next tick, #573
-				const remainingTick = this._clock.frequency.getDurationOfTicks(
-					Math.ceil(ticks) - ticks,
-					now
-				);
-				const time = now + remainingTick;
-				this.emit("stop", time);
-				this._clock.setTicksAtTime(t, time);
-				// restart it with the new time
-				this.emit("start", time, this._clock.getSecondsAtTime(time));
-			} else {
-				this.emit("ticks", now);
-				this._clock.setTicksAtTime(t, now);
-			}
+
+		// "floor" ensures that any events scheduled on this tick will be called.
+		t = Math.floor(t);
+
+		if (this._clock.ticks === t) {
+			return;
+		}
+		const now = this.now();
+		// stop everything synced to the transport
+		if (this.state === "started") {
+			const ticks = this._clock.getTicksAtTime(now);
+			// schedule to start on the next tick, #573
+			const remainingTick = this._clock.frequency.getDurationOfTicks(
+				Math.ceil(ticks) - ticks,
+				now
+			);
+			const time = now + remainingTick;
+			this.emit("stop", time);
+			this._clock.setTicksAtTime(t, time);
+			// restart it with the new time
+			this.emit("start", time, this._clock.getSecondsAtTime(time));
+		} else {
+			this.emit("ticks", now);
+			this._clock.setTicksAtTime(t, now);
 		}
 	}
 


### PR DESCRIPTION
Issue arose when setting a value which was not representable by an integer tick and scheduling a value at that same time. While scheduling values at non-integer ticks is possible, there is a chance that the tick would be passed up if a non-integer tick was set as the transport.seconds. 

Example, 

1. schedule a time for time = 100.4 ticks. 
2. set the transport.ticks = 100.4 ticks. 
3. start the transport
4. The next compute tick time is 101, skipping 100.4. 

Fixes #1294 