### PR TITLE
fix: minimum meter value

### DIFF
--- a/Tone/component/analysis/Meter.test.ts
+++ b/Tone/component/analysis/Meter.test.ts
@@ -69,6 +69,20 @@ describe("Meter", () => {
 			}, 400);
 		});
 
+		it("returns 0 below a threshold", (done) => {
+			const meter = new Meter({
+				normalRange: true,
+			});
+			const osc = new Oscillator().connect(meter).start();
+			osc.volume.value = -101;
+			setTimeout(() => {
+				expect(meter.getValue()).to.equal(0);
+				meter.dispose();
+				osc.dispose();
+				done();
+			}, 400);
+		});
+
 		it("can get the values in normal range", (done) => {
 			const meter = new Meter({
 				normalRange: true,

--- a/Tone/component/analysis/Meter.ts
+++ b/Tone/component/analysis/Meter.ts
@@ -1,4 +1,4 @@
-import { gainToDb } from "../../core/type/Conversions.js";
+import { dbToGain, gainToDb } from "../../core/type/Conversions.js";
 import { NormalRange } from "../../core/type/Units.js";
 import { warn } from "../../core/util/Debug.js";
 import { optionsFromArguments } from "../../core/util/Defaults.js";
@@ -94,6 +94,11 @@ export class Meter extends MeterBase<MeterOptions> {
 	}
 
 	/**
+	 * Below this threshold, stop smoothing.
+	 */
+	private minValue = dbToGain(-100);
+
+	/**
 	 * Get the current value of the incoming signal.
 	 * Output is in decibels when {@link normalRange} is `false`.
 	 * If {@link channels} = 1, then the output is a single number
@@ -106,18 +111,25 @@ export class Meter extends MeterBase<MeterOptions> {
 			this.channels === 1
 				? [aValues as Float32Array]
 				: (aValues as Float32Array[]);
-		const vals = channelValues.map((values, index) => {
+		const vals = channelValues.map((values, channel) => {
 			const totalSquared = values.reduce(
 				(total, current) => total + current * current,
 				0
 			);
 			const rms = Math.sqrt(totalSquared / values.length);
-			// the rms can only fall at the rate of the smoothing
-			// but can jump up instantly
-			this._rms[index] = Math.max(rms, this._rms[index] * this.smoothing);
+			if (rms < this.minValue) {
+				this._rms[channel] = 0;
+			} else {
+				// the rms can only fall at the rate of the smoothing
+				// but can jump up instantly
+				this._rms[channel] = Math.max(
+					rms,
+					this._rms[channel] * this.smoothing
+				);
+			}
 			return this.normalRange
-				? this._rms[index]
-				: gainToDb(this._rms[index]);
+				? this._rms[channel]
+				: gainToDb(this._rms[channel]);
 		});
 		if (this.channels === 1) {
 			return vals[0];

--- a/Tone/core/context/Context.ts
+++ b/Tone/core/context/Context.ts
@@ -40,7 +40,7 @@ export class Context extends BaseContext {
 	readonly name: string = "Context";
 
 	/**
-		 * A private reference to the BaseAudioContext.
+	 * A private reference to the BaseAudioContext.
 	 */
 	protected readonly _context: AnyAudioContext;
 


### PR DESCRIPTION
Because of the smoothing the values would keep moving towards smaller and smaller values. This adds a cutoff at -100db where the values just move to 0 or -Infinity depending on the mode. 