### PR TITLE
fix: Revert added width argument for AutoPanner

### DIFF
--- a/Tone/effect/AutoPanner.test.ts
+++ b/Tone/effect/AutoPanner.test.ts
@@ -87,23 +87,5 @@ describe("AutoPanner", () => {
 			expect(buffer.getValueAtTime(0)).to.be.closeTo(2, 0.1);
 			expect(buffer.getValueAtTime(0.05)).to.be.closeTo(2, 0.1);
 		});
-
-		/**
-		 * Width Tests
-		 */
-		it("can set the width", () => {
-			const autoPanner = new AutoPanner();
-			autoPanner.width = 0.5;
-			expect(autoPanner.width).to.be.closeTo(0.5, 0.01);
-			autoPanner.dispose();
-		});
-		
-		it("can pass width in the constructor", () => {
-			const autoPanner = new AutoPanner({
-				width: 0.3,
-			});
-			expect(autoPanner.width).to.be.closeTo(0.3, 0.01);
-			autoPanner.dispose();
-		});	
 	});
 });

--- a/Tone/effect/AutoPanner.ts
+++ b/Tone/effect/AutoPanner.ts
@@ -1,11 +1,10 @@
 import { Panner } from "../component/channel/Panner.js";
-import { Frequency, NormalRange } from "../core/type/Units.js";
+import { Frequency } from "../core/type/Units.js";
 import { optionsFromArguments } from "../core/util/Defaults.js";
 import { LFOEffect, LFOEffectOptions } from "./LFOEffect.js";
 
 export interface AutoPannerOptions extends LFOEffectOptions {
 	channelCount: number;
-	width: NormalRange;
 }
 
 /**
@@ -25,9 +24,7 @@ export class AutoPanner extends LFOEffect<AutoPannerOptions> {
 	/**
 	 * The filter node
 	 */
-	private readonly _panner: Panner;
-
-	private _width: NormalRange;
+	readonly _panner: Panner;
 
 	/**
 	 * @param frequency Rate of left-right oscillation.
@@ -46,40 +43,17 @@ export class AutoPanner extends LFOEffect<AutoPannerOptions> {
 			context: this.context,
 			channelCount: options.channelCount,
 		});
-
-		this._width = options.width;
-
 		// connections
 		this.connectEffect(this._panner);
 		this._lfo.connect(this._panner.pan);
-		this._updateLFORange();
+		this._lfo.min = -1;
+		this._lfo.max = 1;
 	}
 
 	static getDefaults(): AutoPannerOptions {
 		return Object.assign(LFOEffect.getDefaults(), {
 			channelCount: 1,
-			width: 1,
 		});
-	}
-
-	/**
-	 * Updates the LFO min/max based on width
-	 */
-	private _updateLFORange(): void {
-		this._lfo.min = -this._width;
-		this._lfo.max = this._width;
-	}
-
-	/**
-	 * The width of the panning effect. 0 = no panning, 1 = full left-right panning.
-	 */
-	get width(): NormalRange {
-		return this._width;
-	}
-
-	set width(width: NormalRange) {
-		this._width = width;
-		this._updateLFORange();
 	}
 
 	dispose(): this {


### PR DESCRIPTION
Reverts Tonejs/Tone.js#1399

Realized this width property was redundant with "depth". 