### PR TITLE
feat: onContextRunning

### DIFF
--- a/Tone/core/context/OnRunning.test.ts
+++ b/Tone/core/context/OnRunning.test.ts
@@ -1,0 +1,63 @@
+import { expect } from "chai";
+
+import { Context } from "./Context.js";
+import { OfflineContext } from "./OfflineContext.js";
+import { onContextRunning } from "./OnRunning.js";
+
+context("onContextRunning", () => {
+	it("callback is invoked immediately when offline context is used", () => {
+		const ctx = new OfflineContext(1, 0.1, 44100);
+		let wasInvoked = false;
+
+		onContextRunning(ctx, () => {
+			wasInvoked = true;
+		});
+
+		expect(wasInvoked).to.be.true;
+		ctx.dispose();
+	});
+
+	it("callback is invoked immediately when context is already running", async () => {
+		const ctx = new Context();
+		await ctx.resume();
+		let wasInvoked = false;
+
+		onContextRunning(ctx, () => {
+			wasInvoked = true;
+		});
+
+		expect(wasInvoked).to.be.true;
+		ctx.dispose();
+	});
+
+	it("callback is invoked when the context starts running", async () => {
+		const ctx = new Context();
+		let wasInvoked = false;
+
+		onContextRunning(ctx, () => {
+			wasInvoked = true;
+		});
+
+		expect(wasInvoked).to.be.false;
+
+		await ctx.resume();
+		expect(wasInvoked).to.be.true;
+
+		ctx.dispose();
+	});
+
+	it("can remove the callback with the returned function", async () => {
+		const ctx = new Context();
+		let wasInvoked = false;
+		const remove = onContextRunning(ctx, () => {
+			wasInvoked = true;
+		});
+		expect(wasInvoked).to.be.false;
+		remove();
+
+		await ctx.resume();
+
+		expect(wasInvoked).to.be.false;
+		ctx.dispose();
+	});
+});

--- a/Tone/core/context/OnRunning.ts
+++ b/Tone/core/context/OnRunning.ts
@@ -1,0 +1,26 @@
+import { BaseContext } from "./BaseContext.js";
+
+/**
+ * Invoked when the context is started. The callback is invoked immediately
+ * if the context is already started or when the context is an OfflineContext.
+ * Returns a function which can be called to remove the listener.
+ * @internal Used to trigger certain events when the context has been started.
+ */
+export function onContextRunning(
+	context: BaseContext,
+	callback: () => void
+): () => void {
+	const listener = (state: AudioContextState) => {
+		if (state === "running") {
+			callback();
+			context.off("statechange", listener);
+		}
+	};
+	if (context.isOffline || context.state === "running") {
+		callback();
+		return () => {};
+	}
+
+	context.on("statechange", listener);
+	return () => context.off("statechange", listener);
+}

--- a/Tone/core/context/ToneWithContext.test.ts
+++ b/Tone/core/context/ToneWithContext.test.ts
@@ -1,0 +1,82 @@
+import { expect } from "chai";
+
+import { Offline } from "../../../test/helper/Offline.js";
+import { getContext } from "../Global.js";
+import { Gain } from "./Gain.js";
+import { ToneWithContext } from "./ToneWithContext.js";
+
+describe("ToneWithContext", () => {
+	context("get", () => {
+		it("returns an object with all the default properties", () => {
+			const gain = new Gain();
+			const values = gain.get();
+			expect(values).to.be.an("object");
+			expect(values).to.have.property("gain");
+			gain.dispose();
+		});
+
+		it("reflects the current value of properties", () => {
+			const gain = new Gain(0.3);
+			const values = gain.get();
+			expect(values.gain).to.be.closeTo(0.3, 0.001);
+			gain.dispose();
+		});
+	});
+
+	context("set", () => {
+		it("sets properties with an object", () => {
+			const gain = new Gain();
+			gain.set({ gain: 0.5 });
+			expect(gain.gain.value).to.be.closeTo(0.5, 0.001);
+			gain.dispose();
+		});
+
+		it("returns the instance for chaining", () => {
+			const gain = new Gain();
+			const returned = gain.set({ gain: 0.5 });
+			expect(returned).to.equal(gain);
+			gain.dispose();
+		});
+
+		it("does not set a value if it is the same", () => {
+			const gain = new Gain(0.7);
+			gain.set({ gain: 0.7 });
+			expect(gain.gain.value).to.be.closeTo(0.7, 0.001);
+			gain.dispose();
+		});
+	});
+
+	context("getDefaults", () => {
+		it("returns defaults with a context", () => {
+			const defaults = ToneWithContext.getDefaults();
+			expect(defaults).to.have.property("context");
+			expect(defaults.context).to.equal(getContext());
+		});
+	});
+
+	context("_onContextRunning", () => {
+		it("invokes the callback immediately for an offline context", () => {
+			return Offline(() => {
+				let callbackInvoked = false;
+				const gain = new Gain();
+				// Access protected method via subclass trick
+				(gain as any)._onContextRunning(() => {
+					callbackInvoked = true;
+				});
+				expect(callbackInvoked).to.equal(true);
+				gain.dispose();
+			});
+		});
+
+		it("cleans up the listener on dispose", () => {
+			return Offline(() => {
+				const gain = new Gain();
+				(gain as any)._onContextRunning(() => {
+					// no-op
+				});
+				// Should not throw when disposing
+				gain.dispose();
+			});
+		});
+	});
+});

--- a/Tone/core/context/ToneWithContext.ts
+++ b/Tone/core/context/ToneWithContext.ts
@@ -19,6 +19,7 @@ import {
 	isUndef,
 } from "../util/TypeCheck.js";
 import { BaseContext } from "./BaseContext.js";
+import { onContextRunning } from "./OnRunning.js";
 
 /**
  * A unit which process audio
@@ -230,6 +231,29 @@ export abstract class ToneWithContext<
 				}
 			}
 		});
+		return this;
+	}
+
+	/**
+	 * Internal method which removes the onContextRunning callback.
+	 */
+	private _removeOnContextRunning?: () => void;
+
+	/**
+	 * Internal method which is called the first time the context is resumed.
+	 * Useful for setting up AudioNodes which should be running as soon
+	 * as the context is running, but should not be started until then.
+	 */
+	protected _onContextRunning(callback: () => void): void {
+		this._removeOnContextRunning = onContextRunning(this.context, callback);
+	}
+
+	/**
+	 * Dispose and disconnect
+	 */
+	dispose(): this {
+		super.dispose();
+		this._removeOnContextRunning?.();
 		return this;
 	}
 }

--- a/Tone/core/util/Interface.ts
+++ b/Tone/core/util/Interface.ts
@@ -6,7 +6,10 @@ export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 /**
  * Make the property not writable using `defineProperty`. Internal use only.
  */
-export function readOnly(target: object, property: string | string[]): void {
+export function readOnly<T extends object>(
+	target: T,
+	property: keyof T | (keyof T)[]
+): void {
 	if (isArray(property)) {
 		property.forEach((str) => readOnly(target, str));
 	} else {
@@ -20,7 +23,10 @@ export function readOnly(target: object, property: string | string[]): void {
 /**
  * Make an attribute writeable. Internal use only.
  */
-export function writable(target: object, property: string | string[]): void {
+export function writable<T extends object>(
+	target: T,
+	property: keyof T | (keyof T)[]
+): void {
 	if (isArray(property)) {
 		property.forEach((str) => writable(target, str));
 	} else {

--- a/Tone/effect/FrequencyShifter.ts
+++ b/Tone/effect/FrequencyShifter.ts
@@ -1,4 +1,5 @@
 import { PhaseShiftAllpass } from "../component/filter/PhaseShiftAllpass.js";
+import { onContextRunning } from "../core/context/OnRunning.js";
 import { Frequency } from "../core/type/Units.js";
 import { optionsFromArguments } from "../core/util/Defaults.js";
 import { Effect, EffectOptions } from "../effect/Effect.js";
@@ -76,6 +77,11 @@ export class FrequencyShifter extends Effect<FrequencyShifterOptions> {
 	private _phaseShifter: PhaseShiftAllpass;
 
 	/**
+	 * Clean up the onContextRunning listener.
+	 */
+	private _removeOnRunning?: () => void;
+
+	/**
 	 * @param frequency The incoming signal is shifted by this frequency value.
 	 */
 	constructor(frequency?: Frequency);
@@ -131,9 +137,11 @@ export class FrequencyShifter extends Effect<FrequencyShifterOptions> {
 		this._add.connect(this.effectReturn);
 
 		// start the oscillators at the same time
-		const now = this.immediate();
-		this._sine.start(now);
-		this._cosine.start(now);
+		this._removeOnRunning = onContextRunning(this.context, () => {
+			const now = this.immediate();
+			this._sine.start(now);
+			this._cosine.start(now);
+		});
 	}
 
 	static getDefaults(): FrequencyShifterOptions {
@@ -152,6 +160,7 @@ export class FrequencyShifter extends Effect<FrequencyShifterOptions> {
 		this._phaseShifter.dispose();
 		this._sine.dispose();
 		this._sineMultiply.dispose();
+		this._removeOnRunning?.();
 		return this;
 	}
 }

--- a/Tone/effect/FrequencyShifter.ts
+++ b/Tone/effect/FrequencyShifter.ts
@@ -1,5 +1,4 @@
 import { PhaseShiftAllpass } from "../component/filter/PhaseShiftAllpass.js";
-import { onContextRunning } from "../core/context/OnRunning.js";
 import { Frequency } from "../core/type/Units.js";
 import { optionsFromArguments } from "../core/util/Defaults.js";
 import { Effect, EffectOptions } from "../effect/Effect.js";
@@ -77,11 +76,6 @@ export class FrequencyShifter extends Effect<FrequencyShifterOptions> {
 	private _phaseShifter: PhaseShiftAllpass;
 
 	/**
-	 * Clean up the onContextRunning listener.
-	 */
-	private _removeOnRunning?: () => void;
-
-	/**
 	 * @param frequency The incoming signal is shifted by this frequency value.
 	 */
 	constructor(frequency?: Frequency);
@@ -137,7 +131,7 @@ export class FrequencyShifter extends Effect<FrequencyShifterOptions> {
 		this._add.connect(this.effectReturn);
 
 		// start the oscillators at the same time
-		this._removeOnRunning = onContextRunning(this.context, () => {
+		this._onContextRunning(() => {
 			const now = this.immediate();
 			this._sine.start(now);
 			this._cosine.start(now);
@@ -160,7 +154,6 @@ export class FrequencyShifter extends Effect<FrequencyShifterOptions> {
 		this._phaseShifter.dispose();
 		this._sine.dispose();
 		this._sineMultiply.dispose();
-		this._removeOnRunning?.();
 		return this;
 	}
 }

--- a/Tone/effect/LFOStereoEffect.test.ts
+++ b/Tone/effect/LFOStereoEffect.test.ts
@@ -71,7 +71,7 @@ describe("LFOStereoEffect", () => {
 			expect(buffer.getValueAtTime(0.05)).to.be.closeTo(2, 0.1);
 		});
 
-		it("autostarts the LFO", () => {
+		it("autostart the LFO", () => {
 			const stereoEffect = new LFOStereoEffectTest({
 				frequency: 0.2,
 				autostart: true,

--- a/Tone/effect/LFOStereoEffect.test.ts
+++ b/Tone/effect/LFOStereoEffect.test.ts
@@ -1,0 +1,85 @@
+import { expect } from "chai";
+
+import { BasicTests } from "../../test/helper/Basic.js";
+import { Offline } from "../../test/helper/Offline.js";
+import { LFOStereoEffect, LFOStereoEffectOptions } from "./LFOStereoEffect.js";
+
+describe("LFOStereoEffect", () => {
+	class LFOStereoEffectTest extends LFOStereoEffect<LFOStereoEffectOptions> {
+		getLfoState() {
+			return this._lfoL.state;
+		}
+	}
+
+	BasicTests(LFOStereoEffectTest);
+
+	context("API", () => {
+		it("can pass in options in the constructor", () => {
+			const stereoEffect = new LFOStereoEffectTest({
+				frequency: 0.2,
+			});
+			expect(stereoEffect.frequency.value).to.be.closeTo(0.2, 0.01);
+			stereoEffect.dispose();
+		});
+
+		it("can be started and stopped", () => {
+			const stereoEffect = new LFOStereoEffectTest();
+			stereoEffect.start().stop("+0.2");
+			stereoEffect.dispose();
+		});
+
+		it("can get/set the options", () => {
+			const stereoEffect = new LFOStereoEffectTest();
+			stereoEffect.set({
+				frequency: 2.4,
+			});
+			expect(stereoEffect.get().frequency).to.be.closeTo(2.4, 0.01);
+			stereoEffect.dispose();
+		});
+
+		it("can set the frequency and depth", () => {
+			const stereoEffect = new LFOStereoEffectTest();
+			stereoEffect.frequency.value = 0.4;
+			expect(stereoEffect.frequency.value).to.be.closeTo(0.4, 0.01);
+			stereoEffect.dispose();
+		});
+
+		it("can sync the frequency to the transport", async () => {
+			const buffer = await Offline(({ transport }) => {
+				const stereoEffect = new LFOStereoEffectTest({
+					frequency: 2,
+				});
+				stereoEffect.sync();
+				stereoEffect.frequency.toDestination();
+				transport.bpm.setValueAtTime(transport.bpm.value * 2, 0.05);
+			}, 0.1);
+			expect(buffer.getValueAtTime(0)).to.be.closeTo(2, 0.1);
+			expect(buffer.getValueAtTime(0.05)).to.be.closeTo(4, 0.1);
+		});
+
+		it("can unsync the frequency to the transport", async () => {
+			const buffer = await Offline(({ transport }) => {
+				const stereoEffect = new LFOStereoEffectTest({
+					frequency: 2,
+				});
+				stereoEffect.sync();
+				stereoEffect.frequency.toDestination();
+				transport.bpm.setValueAtTime(transport.bpm.value * 2, 0.05);
+				stereoEffect.unsync();
+			}, 0.1);
+			expect(buffer.getValueAtTime(0)).to.be.closeTo(2, 0.1);
+			expect(buffer.getValueAtTime(0.05)).to.be.closeTo(2, 0.1);
+		});
+
+		it("autostarts the LFO", () => {
+			const stereoEffect = new LFOStereoEffectTest({
+				frequency: 0.2,
+				autostart: true,
+			});
+			expect(stereoEffect.frequency.value).to.be.closeTo(0.2, 0.01);
+
+			expect(stereoEffect.getLfoState()).to.equal("started");
+			stereoEffect.dispose();
+		});
+	});
+});

--- a/Tone/effect/LFOStereoEffect.ts
+++ b/Tone/effect/LFOStereoEffect.ts
@@ -1,0 +1,145 @@
+import { onContextRunning } from "../core/context/OnRunning.js";
+import { Frequency, Time } from "../core/type/Units.js";
+import { optionsFromArguments } from "../core/util/Defaults.js";
+import { readOnly } from "../core/util/Interface.js";
+import { Signal } from "../signal/Signal.js";
+import { LFO } from "../source/oscillator/LFO.js";
+import { ToneOscillatorType } from "../source/oscillator/OscillatorInterface.js";
+import { StereoEffect, StereoEffectOptions } from "./StereoEffect.js";
+
+export interface LFOStereoEffectOptions extends StereoEffectOptions {
+	frequency: Frequency;
+	autostart: boolean;
+}
+
+/**
+ * Base class for stereo effects which modulate the incoming signal with an LFO.
+ *
+ * @category Effect
+ */
+export abstract class LFOStereoEffect<
+	Options extends LFOStereoEffectOptions,
+> extends StereoEffect<Options> {
+	readonly name: string = "LFOStereoEffect";
+
+	/**
+	 * The LFO in the left channel
+	 */
+	protected _lfoL: LFO;
+
+	/**
+	 * The LFO in the right channel
+	 */
+	protected _lfoR: LFO;
+
+	/**
+	 * The frequency of the tremolo.
+	 */
+	readonly frequency: Signal<"frequency">;
+
+	/**
+	 * Clean up the onContextRunning listener.
+	 */
+	private _removeOnRunning?: () => void;
+
+	constructor(options?: Partial<LFOStereoEffectOptions>);
+	constructor() {
+		const options = optionsFromArguments(
+			LFOStereoEffect.getDefaults(),
+			arguments
+		);
+		super(options);
+
+		this._lfoL = new LFO({
+			context: this.context,
+			min: 0,
+			max: 1,
+		});
+		this._lfoR = new LFO({
+			context: this.context,
+			min: 0,
+			max: 1,
+		});
+
+		// control the frequency with a single signal
+		this.frequency = new Signal({
+			context: this.context,
+			value: options.frequency,
+			units: "frequency",
+		});
+		this.frequency.fan(this._lfoL.frequency, this._lfoR.frequency);
+
+		readOnly(this, ["frequency"]);
+
+		if (options.autostart) {
+			this._removeOnRunning = onContextRunning(this.context, () =>
+				this.start(this.immediate())
+			);
+		}
+	}
+
+	static getDefaults(): LFOStereoEffectOptions {
+		return Object.assign(StereoEffect.getDefaults(), {
+			frequency: 10,
+			autostart: false,
+		});
+	}
+
+	/**
+	 * Start the tremolo.
+	 */
+	start(time?: Time): this {
+		this._lfoL.start(time);
+		this._lfoR.start(time);
+		return this;
+	}
+
+	/**
+	 * Stop the tremolo.
+	 */
+	stop(time?: Time): this {
+		this._lfoL.stop(time);
+		this._lfoR.stop(time);
+		return this;
+	}
+
+	/**
+	 * Sync the effect to the transport.
+	 */
+	sync(): this {
+		this._lfoL.sync();
+		this._lfoR.sync();
+		this.context.transport.syncSignal(this.frequency);
+		return this;
+	}
+
+	/**
+	 * Unsync the filter from the transport
+	 */
+	unsync(): this {
+		this._lfoL.unsync();
+		this._lfoR.unsync();
+		this.context.transport.unsyncSignal(this.frequency);
+		return this;
+	}
+
+	/**
+	 * The oscillator type.
+	 */
+	get type(): ToneOscillatorType {
+		return this._lfoL.type;
+	}
+	set type(type) {
+		this._lfoL.type = type;
+		this._lfoR.type = type;
+	}
+
+	dispose(): this {
+		super.dispose();
+		this._lfoL.dispose();
+		this._lfoR.dispose();
+		this.frequency.dispose();
+		this._removeOnRunning?.();
+		return this;
+	}
+}

--- a/Tone/effect/LFOStereoEffect.ts
+++ b/Tone/effect/LFOStereoEffect.ts
@@ -1,4 +1,3 @@
-import { onContextRunning } from "../core/context/OnRunning.js";
 import { Frequency, Time } from "../core/type/Units.js";
 import { optionsFromArguments } from "../core/util/Defaults.js";
 import { readOnly } from "../core/util/Interface.js";
@@ -37,11 +36,6 @@ export abstract class LFOStereoEffect<
 	 */
 	readonly frequency: Signal<"frequency">;
 
-	/**
-	 * Clean up the onContextRunning listener.
-	 */
-	private _removeOnRunning?: () => void;
-
 	constructor(options?: Partial<LFOStereoEffectOptions>);
 	constructor() {
 		const options = optionsFromArguments(
@@ -72,9 +66,7 @@ export abstract class LFOStereoEffect<
 		readOnly(this, ["frequency"]);
 
 		if (options.autostart) {
-			this._removeOnRunning = onContextRunning(this.context, () =>
-				this.start(this.immediate())
-			);
+			this._onContextRunning(() => this.start(this.immediate()));
 		}
 	}
 
@@ -139,7 +131,6 @@ export abstract class LFOStereoEffect<
 		this._lfoL.dispose();
 		this._lfoR.dispose();
 		this.frequency.dispose();
-		this._removeOnRunning?.();
 		return this;
 	}
 }

--- a/Tone/effect/Phaser.ts
+++ b/Tone/effect/Phaser.ts
@@ -3,10 +3,9 @@ import { optionsFromArguments } from "../core/util/Defaults.js";
 import { readOnly } from "../core/util/Interface.js";
 import { Signal } from "../signal/Signal.js";
 import { LFO } from "../source/oscillator/LFO.js";
-import { StereoEffect, StereoEffectOptions } from "./StereoEffect.js";
+import { LFOStereoEffect, LFOStereoEffectOptions } from "./LFOStereoEffect.js";
 
-export interface PhaserOptions extends StereoEffectOptions {
-	frequency: Frequency;
+export interface PhaserOptions extends LFOStereoEffectOptions {
 	octaves: Positive;
 	stages: Positive;
 	Q: Positive;
@@ -28,18 +27,8 @@ export interface PhaserOptions extends StereoEffectOptions {
  * synth.triggerAttackRelease("E3", "2n");
  * @category Effect
  */
-export class Phaser extends StereoEffect<PhaserOptions> {
+export class Phaser extends LFOStereoEffect<PhaserOptions> {
 	readonly name: string = "Phaser";
-
-	/**
-	 * the lfo which controls the frequency on the left side
-	 */
-	private _lfoL: LFO;
-
-	/**
-	 * the lfo which controls the frequency on the right side
-	 */
-	private _lfoR: LFO;
 
 	/**
 	 * the base modulation frequency
@@ -67,11 +56,6 @@ export class Phaser extends StereoEffect<PhaserOptions> {
 	private _filtersR: BiquadFilterNode[];
 
 	/**
-	 * the frequency of the effect
-	 */
-	readonly frequency: Signal<"frequency">;
-
-	/**
 	 * @param frequency The speed of the phasing.
 	 * @param octaves The octaves of the effect.
 	 * @param baseFrequency The base frequency of the filters.
@@ -90,19 +74,8 @@ export class Phaser extends StereoEffect<PhaserOptions> {
 		]);
 		super(options);
 
-		this._lfoL = new LFO({
-			context: this.context,
-			frequency: options.frequency,
-			min: 0,
-			max: 1,
-		});
-		this._lfoR = new LFO({
-			context: this.context,
-			frequency: options.frequency,
-			min: 0,
-			max: 1,
-			phase: 180,
-		});
+		this._lfoR.phase = 180;
+
 		this._baseFrequency = this.toFrequency(options.baseFrequency);
 		this._octaves = options.octaves;
 		this.Q = new Signal({
@@ -113,30 +86,24 @@ export class Phaser extends StereoEffect<PhaserOptions> {
 		this._filtersL = this._makeFilters(options.stages, this._lfoL);
 		this._filtersR = this._makeFilters(options.stages, this._lfoR);
 
-		this.frequency = this._lfoL.frequency;
-		this.frequency.value = options.frequency;
-
 		// connect them up
 		this.connectEffectLeft(...this._filtersL);
 		this.connectEffectRight(...this._filtersR);
-		// control the frequency with one LFO
-		this._lfoL.frequency.connect(this._lfoR.frequency);
+
 		// set the options
 		this.baseFrequency = options.baseFrequency;
 		this.octaves = options.octaves;
-		// start the lfo
-		this._lfoL.start();
-		this._lfoR.start();
-		readOnly(this, ["frequency", "Q"]);
+		readOnly(this, ["Q"]);
 	}
 
 	static getDefaults(): PhaserOptions {
-		return Object.assign(StereoEffect.getDefaults(), {
+		return Object.assign(LFOStereoEffect.getDefaults(), {
 			frequency: 0.5,
 			octaves: 3,
 			stages: 10,
 			Q: 10,
 			baseFrequency: 350,
+			autostart: true,
 		});
 	}
 
@@ -185,11 +152,8 @@ export class Phaser extends StereoEffect<PhaserOptions> {
 	dispose(): this {
 		super.dispose();
 		this.Q.dispose();
-		this._lfoL.dispose();
-		this._lfoR.dispose();
 		this._filtersL.forEach((f) => f.disconnect());
 		this._filtersR.forEach((f) => f.disconnect());
-		this.frequency.dispose();
 		return this;
 	}
 }

--- a/Tone/effect/PitchShift.ts
+++ b/Tone/effect/PitchShift.ts
@@ -1,5 +1,6 @@
 import { CrossFade } from "../component/channel/CrossFade.js";
 import { Delay } from "../core/context/Delay.js";
+import { onContextRunning } from "../core/context/OnRunning.js";
 import { Param } from "../core/context/Param.js";
 import { intervalToFrequencyRatio } from "../core/type/Conversions.js";
 import { Interval, Seconds, Time } from "../core/type/Units.js";
@@ -83,6 +84,11 @@ export class PitchShift extends FeedbackEffect<PitchShiftOptions> {
 	private _windowSize;
 
 	/**
+	 * Clean up the onContextRunning listener.
+	 */
+	private _removeOnRunning?: () => void;
+
+	/**
 	 * @param pitch The interval to transpose the incoming signal by.
 	 */
 	constructor(pitch?: Interval);
@@ -147,13 +153,16 @@ export class PitchShift extends FeedbackEffect<PitchShiftOptions> {
 		// route the input
 		this.effectSend.fan(this._delayA, this._delayB);
 		this._crossFade.chain(this._feedbackDelay, this.effectReturn);
-		// start the LFOs at the same time
-		const now = this.now();
-		this._lfoA.start(now);
-		this._lfoB.start(now);
-		this._crossFadeLFO.start(now);
 		// set the initial value
 		this.windowSize = this._windowSize;
+
+		// start the LFOs at the same time
+		this._removeOnRunning = onContextRunning(this.context, () => {
+			const now = this.immediate();
+			this._lfoA.start(now);
+			this._lfoB.start(now);
+			this._crossFadeLFO.start(now);
+		});
 	}
 
 	static getDefaults(): PitchShiftOptions {
@@ -219,6 +228,7 @@ export class PitchShift extends FeedbackEffect<PitchShiftOptions> {
 		this._crossFade.dispose();
 		this._crossFadeLFO.dispose();
 		this._feedbackDelay.dispose();
+		this._removeOnRunning?.();
 		return this;
 	}
 }

--- a/Tone/effect/PitchShift.ts
+++ b/Tone/effect/PitchShift.ts
@@ -1,6 +1,5 @@
 import { CrossFade } from "../component/channel/CrossFade.js";
 import { Delay } from "../core/context/Delay.js";
-import { onContextRunning } from "../core/context/OnRunning.js";
 import { Param } from "../core/context/Param.js";
 import { intervalToFrequencyRatio } from "../core/type/Conversions.js";
 import { Interval, Seconds, Time } from "../core/type/Units.js";
@@ -84,11 +83,6 @@ export class PitchShift extends FeedbackEffect<PitchShiftOptions> {
 	private _windowSize;
 
 	/**
-	 * Clean up the onContextRunning listener.
-	 */
-	private _removeOnRunning?: () => void;
-
-	/**
 	 * @param pitch The interval to transpose the incoming signal by.
 	 */
 	constructor(pitch?: Interval);
@@ -157,7 +151,7 @@ export class PitchShift extends FeedbackEffect<PitchShiftOptions> {
 		this.windowSize = this._windowSize;
 
 		// start the LFOs at the same time
-		this._removeOnRunning = onContextRunning(this.context, () => {
+		this._onContextRunning(() => {
 			const now = this.immediate();
 			this._lfoA.start(now);
 			this._lfoB.start(now);
@@ -228,7 +222,6 @@ export class PitchShift extends FeedbackEffect<PitchShiftOptions> {
 		this._crossFade.dispose();
 		this._crossFadeLFO.dispose();
 		this._feedbackDelay.dispose();
-		this._removeOnRunning?.();
 		return this;
 	}
 }

--- a/Tone/effect/StereoWidener.ts
+++ b/Tone/effect/StereoWidener.ts
@@ -1,4 +1,3 @@
-import { connect } from "../core/context/ToneAudioNode.js";
 import { NormalRange } from "../core/type/Units.js";
 import { optionsFromArguments } from "../core/util/Defaults.js";
 import { readOnly } from "../core/util/Interface.js";
@@ -9,6 +8,7 @@ import {
 import { Multiply } from "../signal/Multiply.js";
 import { Signal } from "../signal/Signal.js";
 import { Subtract } from "../signal/Subtract.js";
+import { ToneConstantSource } from "../signal/ToneConstantSource.js";
 
 export interface StereoWidenerOptions extends MidSideEffectOptions {
 	width: NormalRange;
@@ -58,6 +58,11 @@ export class StereoWidener extends MidSideEffect<StereoWidenerOptions> {
 	private _sideMult: Multiply;
 
 	/**
+	 * A constant source to get the value of 1 for the subtract node
+	 */
+	private _constant: ToneConstantSource;
+
+	/**
 	 * @param width The stereo width. A width of 0 is mono and 1 is stereo. 0.5 is no change.
 	 */
 	constructor(width?: NormalRange);
@@ -90,7 +95,11 @@ export class StereoWidener extends MidSideEffect<StereoWidenerOptions> {
 
 		this._oneMinusWidth = new Subtract({ context: this.context });
 		this._oneMinusWidth.connect(this._twoTimesWidthMid);
-		connect(this.context.getConstant(1), this._oneMinusWidth);
+		this._constant = new ToneConstantSource({
+			context: this.context,
+			offset: 1,
+		}).start();
+		this._constant.connect(this._oneMinusWidth);
 		this.width.connect(this._oneMinusWidth.subtrahend);
 
 		this._sideMult = new Multiply({ context: this.context });
@@ -113,6 +122,7 @@ export class StereoWidener extends MidSideEffect<StereoWidenerOptions> {
 		this._twoTimesWidthMid.dispose();
 		this._twoTimesWidthSide.dispose();
 		this._oneMinusWidth.dispose();
+		this._constant.dispose();
 		return this;
 	}
 }

--- a/Tone/effect/Tremolo.test.ts
+++ b/Tone/effect/Tremolo.test.ts
@@ -60,28 +60,5 @@ describe("Tremolo", () => {
 			expect(tremolo.frequency.value).to.be.closeTo(0.4, 0.01);
 			tremolo.dispose();
 		});
-
-		it("can sync the frequency to the transport", async () => {
-			const buffer = await Offline(({ transport }) => {
-				const tremolo = new Tremolo(2);
-				tremolo.sync();
-				tremolo.frequency.toDestination();
-				transport.bpm.setValueAtTime(transport.bpm.value * 2, 0.05);
-			}, 0.1);
-			expect(buffer.getValueAtTime(0)).to.be.closeTo(2, 0.1);
-			expect(buffer.getValueAtTime(0.05)).to.be.closeTo(4, 0.1);
-		});
-
-		it("can unsync the frequency to the transport", async () => {
-			const buffer = await Offline(({ transport }) => {
-				const tremolo = new Tremolo(2);
-				tremolo.sync();
-				tremolo.frequency.toDestination();
-				transport.bpm.setValueAtTime(transport.bpm.value * 2, 0.05);
-				tremolo.unsync();
-			}, 0.1);
-			expect(buffer.getValueAtTime(0)).to.be.closeTo(2, 0.1);
-			expect(buffer.getValueAtTime(0.05)).to.be.closeTo(2, 0.1);
-		});
 	});
 });

--- a/Tone/effect/Tremolo.test.ts
+++ b/Tone/effect/Tremolo.test.ts
@@ -3,7 +3,6 @@ import { expect } from "chai";
 import { BasicTests } from "../../test/helper/Basic.js";
 import { CompareToFile } from "../../test/helper/CompareToFile.js";
 import { EffectTests } from "../../test/helper/EffectTests.js";
-import { Offline } from "../../test/helper/Offline.js";
 import { Oscillator } from "../source/index.js";
 import { Tremolo } from "./Tremolo.js";
 

--- a/Tone/effect/Tremolo.ts
+++ b/Tone/effect/Tremolo.ts
@@ -117,8 +117,6 @@ export class Tremolo extends LFOStereoEffect<TremoloOptions> {
 
 	dispose(): this {
 		super.dispose();
-		this._lfoL.dispose();
-		this._lfoR.dispose();
 		this._amplitudeL.dispose();
 		this._amplitudeR.dispose();
 		this.depth.dispose();

--- a/Tone/effect/Tremolo.ts
+++ b/Tone/effect/Tremolo.ts
@@ -1,13 +1,12 @@
 import { Gain } from "../core/context/Gain.js";
-import { Degrees, Frequency, NormalRange, Time } from "../core/type/Units.js";
+import { Degrees, Frequency, NormalRange } from "../core/type/Units.js";
 import { optionsFromArguments } from "../core/util/Defaults.js";
 import { readOnly } from "../core/util/Interface.js";
 import { Signal } from "../signal/Signal.js";
-import { LFO } from "../source/oscillator/LFO.js";
 import { ToneOscillatorType } from "../source/oscillator/OscillatorInterface.js";
-import { StereoEffect, StereoEffectOptions } from "./StereoEffect.js";
+import { LFOStereoEffect, LFOStereoEffectOptions } from "./LFOStereoEffect.js";
 
-export interface TremoloOptions extends StereoEffectOptions {
+export interface TremoloOptions extends LFOStereoEffectOptions {
 	frequency: Frequency;
 	type: ToneOscillatorType;
 	depth: NormalRange;
@@ -26,18 +25,8 @@ export interface TremoloOptions extends StereoEffectOptions {
  *
  * @category Effect
  */
-export class Tremolo extends StereoEffect<TremoloOptions> {
+export class Tremolo extends LFOStereoEffect<TremoloOptions> {
 	readonly name: string = "Tremolo";
-
-	/**
-	 * The tremolo LFO in the left channel
-	 */
-	private _lfoL: LFO;
-
-	/**
-	 * The tremolo LFO in the left channel
-	 */
-	private _lfoR: LFO;
 
 	/**
 	 * Where the gain is multiplied
@@ -48,11 +37,6 @@ export class Tremolo extends StereoEffect<TremoloOptions> {
 	 * Where the gain is multiplied
 	 */
 	private _amplitudeR: Gain;
-
-	/**
-	 * The frequency of the tremolo.
-	 */
-	readonly frequency: Signal<"frequency">;
 
 	/**
 	 * The depth of the effect. A depth of 0, has no effect
@@ -74,25 +58,16 @@ export class Tremolo extends StereoEffect<TremoloOptions> {
 		]);
 		super(options);
 
-		this._lfoL = new LFO({
-			context: this.context,
-			type: options.type,
-			min: 1,
-			max: 0,
-		});
-		this._lfoR = new LFO({
-			context: this.context,
-			type: options.type,
-			min: 1,
-			max: 0,
-		});
+		// invert the lfo min/max so it moves from full gain to 0 gain
+		this._lfoL.min = 1;
+		this._lfoL.max = 0;
+		this._lfoR.min = 1;
+		this._lfoR.max = 0;
+		this.type = options.type;
+
 		this._amplitudeL = new Gain({ context: this.context });
 		this._amplitudeR = new Gain({ context: this.context });
-		this.frequency = new Signal({
-			context: this.context,
-			value: options.frequency,
-			units: "frequency",
-		});
+
 		this.depth = new Signal({
 			context: this.context,
 			value: options.depth,
@@ -104,56 +79,17 @@ export class Tremolo extends StereoEffect<TremoloOptions> {
 		this.connectEffectRight(this._amplitudeR);
 		this._lfoL.connect(this._amplitudeL.gain);
 		this._lfoR.connect(this._amplitudeR.gain);
-		this.frequency.fan(this._lfoL.frequency, this._lfoR.frequency);
 		this.depth.fan(this._lfoR.amplitude, this._lfoL.amplitude);
 		this.spread = options.spread;
 	}
 
 	static getDefaults(): TremoloOptions {
-		return Object.assign(StereoEffect.getDefaults(), {
+		return Object.assign(LFOStereoEffect.getDefaults(), {
 			frequency: 10,
 			type: "sine" as const,
 			depth: 0.5,
 			spread: 180,
 		});
-	}
-
-	/**
-	 * Start the tremolo.
-	 */
-	start(time?: Time): this {
-		this._lfoL.start(time);
-		this._lfoR.start(time);
-		return this;
-	}
-
-	/**
-	 * Stop the tremolo.
-	 */
-	stop(time?: Time): this {
-		this._lfoL.stop(time);
-		this._lfoR.stop(time);
-		return this;
-	}
-
-	/**
-	 * Sync the effect to the transport.
-	 */
-	sync(): this {
-		this._lfoL.sync();
-		this._lfoR.sync();
-		this.context.transport.syncSignal(this.frequency);
-		return this;
-	}
-
-	/**
-	 * Unsync the filter from the transport
-	 */
-	unsync(): this {
-		this._lfoL.unsync();
-		this._lfoR.unsync();
-		this.context.transport.unsyncSignal(this.frequency);
-		return this;
 	}
 
 	/**
@@ -185,7 +121,6 @@ export class Tremolo extends StereoEffect<TremoloOptions> {
 		this._lfoR.dispose();
 		this._amplitudeL.dispose();
 		this._amplitudeR.dispose();
-		this.frequency.dispose();
 		this.depth.dispose();
 		return this;
 	}

--- a/Tone/effect/Vibrato.ts
+++ b/Tone/effect/Vibrato.ts
@@ -1,5 +1,4 @@
 import { Delay } from "../core/context/Delay.js";
-import { onContextRunning } from "../core/context/OnRunning.js";
 import { Param } from "../core/context/Param.js";
 import { Frequency, NormalRange, Seconds } from "../core/type/Units.js";
 import { optionsFromArguments } from "../core/util/Defaults.js";
@@ -42,11 +41,6 @@ export class Vibrato extends Effect<VibratoOptions> {
 	 */
 	readonly depth: Param<"normalRange">;
 
-	/*
-	 * Clean up the onContextRunning listener.
-	 */
-	private _disposeOnRunning: () => void;
-
 	/**
 	 * @param frequency The frequency of the vibrato.
 	 * @param depth The amount the pitch is modulated.
@@ -80,7 +74,7 @@ export class Vibrato extends Effect<VibratoOptions> {
 		readOnly(this, ["frequency", "depth"]);
 		this.effectSend.chain(this._delayNode, this.effectReturn);
 
-		this._disposeOnRunning = onContextRunning(this.context, () => {
+		this._onContextRunning(() => {
 			this._lfo.start();
 		});
 	}
@@ -110,7 +104,6 @@ export class Vibrato extends Effect<VibratoOptions> {
 		this._lfo.dispose();
 		this.frequency.dispose();
 		this.depth.dispose();
-		this._disposeOnRunning();
 		return this;
 	}
 }

--- a/Tone/effect/Vibrato.ts
+++ b/Tone/effect/Vibrato.ts
@@ -1,4 +1,5 @@
 import { Delay } from "../core/context/Delay.js";
+import { onContextRunning } from "../core/context/OnRunning.js";
 import { Param } from "../core/context/Param.js";
 import { Frequency, NormalRange, Seconds } from "../core/type/Units.js";
 import { optionsFromArguments } from "../core/util/Defaults.js";
@@ -41,6 +42,11 @@ export class Vibrato extends Effect<VibratoOptions> {
 	 */
 	readonly depth: Param<"normalRange">;
 
+	/*
+	 * Clean up the onContextRunning listener.
+	 */
+	private _disposeOnRunning: () => void;
+
 	/**
 	 * @param frequency The frequency of the vibrato.
 	 * @param depth The amount the pitch is modulated.
@@ -66,15 +72,17 @@ export class Vibrato extends Effect<VibratoOptions> {
 			max: options.maxDelay,
 			frequency: options.frequency,
 			phase: -90, // offset the phase so the resting position is in the center
-		})
-			.start()
-			.connect(this._delayNode.delayTime);
+		}).connect(this._delayNode.delayTime);
 		this.frequency = this._lfo.frequency;
 		this.depth = this._lfo.amplitude;
 
 		this.depth.value = options.depth;
 		readOnly(this, ["frequency", "depth"]);
 		this.effectSend.chain(this._delayNode, this.effectReturn);
+
+		this._disposeOnRunning = onContextRunning(this.context, () => {
+			this._lfo.start();
+		});
 	}
 
 	static getDefaults(): VibratoOptions {
@@ -102,6 +110,7 @@ export class Vibrato extends Effect<VibratoOptions> {
 		this._lfo.dispose();
 		this.frequency.dispose();
 		this.depth.dispose();
+		this._disposeOnRunning();
 		return this;
 	}
 }

--- a/Tone/signal/ToneConstantSource.ts
+++ b/Tone/signal/ToneConstantSource.ts
@@ -1,3 +1,4 @@
+import { onContextRunning } from "../core/context/OnRunning.js";
 import { Param } from "../core/context/Param.js";
 import { connect } from "../core/context/ToneAudioNode.js";
 import { Seconds, Time, UnitMap, UnitName } from "../core/type/Units.js";
@@ -37,6 +38,11 @@ export class ToneConstantSource<
 	readonly offset: Param<TypeName>;
 
 	/**
+	 * Clean up the onContextRunning listener.
+	 */
+	private _removeOnRunning?: () => void;
+
+	/**
 	 * @param  offset   The offset value
 	 */
 	constructor(offset: UnitMap[TypeName]);
@@ -49,24 +55,18 @@ export class ToneConstantSource<
 		);
 		super(options);
 
-		const isSuspended =
-			!this.context.isOffline && this.context.state !== "running";
-
-		if (!isSuspended) {
-			this._source = this.context.createConstantSource();
-			connect(this._source, this._gainNode);
-		} else {
-			this.context.on("statechange", this._contextStarted);
-		}
+		this._removeOnRunning = onContextRunning(this.context, () =>
+			this._contextStarted()
+		);
 
 		this.offset = new Param({
 			context: this.context,
 			convert: options.convert,
-			param: isSuspended
+			param: !this._source
 				? // placeholder param until the context is started
 					this.context.createGain().gain
-				: this._source?.offset,
-			swappable: isSuspended,
+				: this._source.offset,
+			swappable: !this._source,
 			units: options.units,
 			value: options.offset,
 			minValue: options.minValue,
@@ -85,17 +85,14 @@ export class ToneConstantSource<
 	/**
 	 * Once the context is started, kick off source.
 	 */
-	private readonly _contextStarted = (state: AudioContextState) => {
-		if (state !== "running") {
-			return;
-		}
+	private _contextStarted() {
 		this._source = this.context.createConstantSource();
 		connect(this._source, this._gainNode);
-		this.offset.setParam(this._source.offset);
+		this.offset?.setParam(this._source.offset);
 		if (this.state === "started") {
 			this._source.start(0);
 		}
-	};
+	}
 
 	/**
 	 * Start the source node at the given time
@@ -123,7 +120,7 @@ export class ToneConstantSource<
 		}
 		this._source?.disconnect();
 		this.offset.dispose();
-		this.context.off("statechange", this._contextStarted);
+		this._removeOnRunning?.();
 		return this;
 	}
 }

--- a/Tone/signal/ToneConstantSource.ts
+++ b/Tone/signal/ToneConstantSource.ts
@@ -1,4 +1,3 @@
-import { onContextRunning } from "../core/context/OnRunning.js";
 import { Param } from "../core/context/Param.js";
 import { connect } from "../core/context/ToneAudioNode.js";
 import { Seconds, Time, UnitMap, UnitName } from "../core/type/Units.js";
@@ -38,11 +37,6 @@ export class ToneConstantSource<
 	readonly offset: Param<TypeName>;
 
 	/**
-	 * Clean up the onContextRunning listener.
-	 */
-	private _removeOnRunning?: () => void;
-
-	/**
 	 * @param  offset   The offset value
 	 */
 	constructor(offset: UnitMap[TypeName]);
@@ -55,9 +49,7 @@ export class ToneConstantSource<
 		);
 		super(options);
 
-		this._removeOnRunning = onContextRunning(this.context, () =>
-			this._contextStarted()
-		);
+		this._onContextRunning(() => this._contextStarted());
 
 		this.offset = new Param({
 			context: this.context,
@@ -120,7 +112,6 @@ export class ToneConstantSource<
 		}
 		this._source?.disconnect();
 		this.offset.dispose();
-		this._removeOnRunning?.();
 		return this;
 	}
 }

--- a/Tone/signal/WaveShaper.ts
+++ b/Tone/signal/WaveShaper.ts
@@ -1,4 +1,3 @@
-import { onContextRunning } from "../core/context/OnRunning.js";
 import { ToneAudioNodeOptions } from "../core/context/ToneAudioNode.js";
 import { assert } from "../core/util/Debug.js";
 import { optionsFromArguments } from "../core/util/Defaults.js";
@@ -46,11 +45,6 @@ export class WaveShaper extends SignalOperator<WaveShaperOptions> {
 	output = this._shaper;
 
 	/**
-	 * Clean up the onContextRunning listener.
-	 */
-	private _disposeOnRunning: () => void;
-
-	/**
 	 * @param mapping The function used to define the values.
 	 *                The mapping function should take two arguments:
 	 *                the first is the value at the current position
@@ -72,9 +66,9 @@ export class WaveShaper extends SignalOperator<WaveShaperOptions> {
 		);
 		super(options);
 
-		this._disposeOnRunning = onContextRunning(this.context, () =>
-			this.initCurve(options.mapping, options.length)
-		);
+		this._onContextRunning(() => {
+			this.initCurve(options.mapping, options.length);
+		});
 	}
 
 	static getDefaults(): WaveShaperOptions {
@@ -155,7 +149,6 @@ export class WaveShaper extends SignalOperator<WaveShaperOptions> {
 	dispose(): this {
 		super.dispose();
 		this._shaper.disconnect();
-		this._disposeOnRunning();
 		return this;
 	}
 }

--- a/Tone/signal/WaveShaper.ts
+++ b/Tone/signal/WaveShaper.ts
@@ -1,3 +1,4 @@
+import { onContextRunning } from "../core/context/OnRunning.js";
 import { ToneAudioNodeOptions } from "../core/context/ToneAudioNode.js";
 import { assert } from "../core/util/Debug.js";
 import { optionsFromArguments } from "../core/util/Defaults.js";
@@ -45,6 +46,11 @@ export class WaveShaper extends SignalOperator<WaveShaperOptions> {
 	output = this._shaper;
 
 	/**
+	 * Clean up the onContextRunning listener.
+	 */
+	private _disposeOnRunning: () => void;
+
+	/**
 	 * @param mapping The function used to define the values.
 	 *                The mapping function should take two arguments:
 	 *                the first is the value at the current position
@@ -66,20 +72,27 @@ export class WaveShaper extends SignalOperator<WaveShaperOptions> {
 		);
 		super(options);
 
-		if (
-			isArray(options.mapping) ||
-			options.mapping instanceof Float32Array
-		) {
-			this.curve = Float32Array.from(options.mapping);
-		} else if (isFunction(options.mapping)) {
-			this.setMap(options.mapping, options.length);
-		}
+		this._disposeOnRunning = onContextRunning(this.context, () =>
+			this.initCurve(options.mapping, options.length)
+		);
 	}
 
 	static getDefaults(): WaveShaperOptions {
 		return Object.assign(Signal.getDefaults(), {
 			length: 1024,
 		});
+	}
+
+	/**
+	 * Set the curve for the first time. This is run only after the audio context is
+	 * running to avoid any context warnings.
+	 */
+	private initCurve(mapping?: WaveShaperMapping, length?: number): void {
+		if (isArray(mapping) || mapping instanceof Float32Array) {
+			this.curve = Float32Array.from(mapping);
+		} else if (isFunction(mapping)) {
+			this.setMap(mapping, length);
+		}
 	}
 
 	/**
@@ -142,6 +155,7 @@ export class WaveShaper extends SignalOperator<WaveShaperOptions> {
 	dispose(): this {
 		super.dispose();
 		this._shaper.disconnect();
+		this._disposeOnRunning();
 		return this;
 	}
 }

--- a/test/helper/Basic.ts
+++ b/test/helper/Basic.ts
@@ -4,10 +4,11 @@ import "../../Tone/core/context/Destination.js";
 import { expect } from "chai";
 
 import * as Classes from "../../Tone/classes.js";
+import { createAudioContext } from "../../Tone/core/context/AudioContext.js";
 import { OfflineContext } from "../../Tone/core/context/OfflineContext.js";
 import { ToneAudioNode } from "../../Tone/core/context/ToneAudioNode.js";
 import { ToneWithContext } from "../../Tone/core/context/ToneWithContext.js";
-import { getContext } from "../../Tone/core/Global.js";
+import { getContext, setContext } from "../../Tone/core/Global.js";
 import { Tone } from "../../Tone/core/Tone.js";
 import { setLogger } from "../../Tone/core/util/Debug.js";
 import { noOp } from "../../Tone/core/util/Interface.js";
@@ -95,6 +96,23 @@ export function BasicTests(Constr, ...args: any[]): void {
 				instance.dispose();
 			}
 		}
+	});
+
+	it("can be created in a suspended context and then resumed", async () => {
+		const originalContext = getContext();
+		const audioContext = createAudioContext();
+		await audioContext.suspend();
+		setContext(audioContext, false);
+		const instance = new Constr(...args);
+
+		expect(audioContext.state).to.equal("suspended");
+		await audioContext.resume();
+		expect(audioContext.state).to.equal("running");
+
+		// restore the original context
+		instance.dispose();
+		setContext(originalContext);
+		audioContext.close();
 	});
 }
 


### PR DESCRIPTION
Adds a helper onContextRunning which invokes a callback when the context is up and running. This is helpful for setting up nodes in the constructor that need to be run only when the audio context is already start. 

Fixes #1392