### PR TITLE
fix: use native ConstantSourceNode in CrossFade and StereoWidener

### DIFF
--- a/Tone/component/channel/CrossFade.ts
+++ b/Tone/component/channel/CrossFade.ts
@@ -9,7 +9,6 @@ import { optionsFromArguments } from "../../core/util/Defaults.js";
 import { readOnly } from "../../core/util/Interface.js";
 import { GainToAudio } from "../../signal/GainToAudio.js";
 import { Signal } from "../../signal/Signal.js";
-import { ToneConstantSource } from "../../signal/ToneConstantSource.js";
 
 interface CrossFadeOptions extends ToneAudioNodeOptions {
 	fade: NormalRange;
@@ -63,7 +62,7 @@ export class CrossFade extends ToneAudioNode<CrossFadeOptions> {
 	/**
 	 * The constant source which is used to control the panner
 	 */
-	private _constant: ToneConstantSource;
+	private _constant: ConstantSourceNode;
 
 	/**
 	 * The input which is at full level when fade = 0
@@ -120,10 +119,9 @@ export class CrossFade extends ToneAudioNode<CrossFadeOptions> {
 		});
 		readOnly(this, "fade");
 
-		this._constant = new ToneConstantSource({
-			context: this.context,
-			offset: 1,
-		}).start();
+		this._constant = this.context.createConstantSource();
+		this._constant.offset.value = 1;
+		this._constant.start(0);
 		this._constant.connect(this._panner);
 		this._panner.connect(this._split);
 		// this is necessary for standardized-audio-context
@@ -155,7 +153,7 @@ export class CrossFade extends ToneAudioNode<CrossFadeOptions> {
 		this._g2a.dispose();
 		this._panner.disconnect();
 		this._split.disconnect();
-		this._constant.dispose();
+		this._constant.disconnect();
 		return this;
 	}
 }

--- a/Tone/effect/StereoWidener.ts
+++ b/Tone/effect/StereoWidener.ts
@@ -1,3 +1,4 @@
+import { connect } from "../core/context/ToneAudioNode.js";
 import { NormalRange } from "../core/type/Units.js";
 import { optionsFromArguments } from "../core/util/Defaults.js";
 import { readOnly } from "../core/util/Interface.js";
@@ -8,7 +9,6 @@ import {
 import { Multiply } from "../signal/Multiply.js";
 import { Signal } from "../signal/Signal.js";
 import { Subtract } from "../signal/Subtract.js";
-import { ToneConstantSource } from "../signal/ToneConstantSource.js";
 
 export interface StereoWidenerOptions extends MidSideEffectOptions {
 	width: NormalRange;
@@ -60,7 +60,7 @@ export class StereoWidener extends MidSideEffect<StereoWidenerOptions> {
 	/**
 	 * A constant source to get the value of 1 for the subtract node
 	 */
-	private _constant: ToneConstantSource;
+	private _constant: ConstantSourceNode;
 
 	/**
 	 * @param width The stereo width. A width of 0 is mono and 1 is stereo. 0.5 is no change.
@@ -95,11 +95,10 @@ export class StereoWidener extends MidSideEffect<StereoWidenerOptions> {
 
 		this._oneMinusWidth = new Subtract({ context: this.context });
 		this._oneMinusWidth.connect(this._twoTimesWidthMid);
-		this._constant = new ToneConstantSource({
-			context: this.context,
-			offset: 1,
-		}).start();
-		this._constant.connect(this._oneMinusWidth);
+		this._constant = this.context.createConstantSource();
+		this._constant.offset.value = 1;
+		this._constant.start(0);
+		connect(this._constant, this._oneMinusWidth);
 		this.width.connect(this._oneMinusWidth.subtrahend);
 
 		this._sideMult = new Multiply({ context: this.context });
@@ -122,7 +121,7 @@ export class StereoWidener extends MidSideEffect<StereoWidenerOptions> {
 		this._twoTimesWidthMid.dispose();
 		this._twoTimesWidthSide.dispose();
 		this._oneMinusWidth.dispose();
-		this._constant.dispose();
+		this._constant.disconnect();
 		return this;
 	}
 }


### PR DESCRIPTION
## Summary

`CrossFade` and `StereoWidener` each create a `ToneConstantSource` that outputs a static value of `1` to drive gain computations. After #1407, `ToneConstantSource` defers native node creation via `_onContextRunning`. When these classes are constructed on a suspended context, the constant source may not produce output, leaving both gain coefficients at `0`, silencing all audio through the node.

Every `Effect` subclass depends on `CrossFade` for dry/wet control, so this affects all effects in the library.

This PR replaces `ToneConstantSource` with a native `ConstantSourceNode` in both classes. Neither uses scheduling, start/stop lifecycle, or unit conversion. They just need a constant `1`, immediately, for the lifetime of the node.

Fixes #1392 (regression from #1407)

## Changes

- **CrossFade**: replace `ToneConstantSource` with native `ConstantSourceNode`
- **StereoWidener**: same fix, using `connect()` from `ToneAudioNode` to handle the native-to-Tone node connection

## Test plan

- [x] Component tests pass (487 passed, 0 failed)
- [x] Effect tests pass (325 passed, 0 failed)
- [x] TypeScript compiles cleanly via `ts:build`
- [ ] Verify no autoplay warnings in Chrome (original #1392 fix preserved)
- [ ] Verify effects produce audio when constructed on a suspended context