### PR TITLE
chore: fix coverage link and type context-running tests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Tone.js has an extensive [test suite](https://github.com/Tonejs/Tone.js/wiki/Tes
 
 Along with more unit tests, it'd also be great to have more tests which run in the online context and generate music to help find bugs by ear that the automated tests might not illuminate. [Audiokit](http://audiokit.io/tests/), for example, has a great suite of aural tests.
 
-You can also take a look at Tone.js' [code coverage](https://coveralls.io/github/Tonejs/Tone.js) to get an idea of where more tests might be helpful.
+You can also take a look at Tone.js' [code coverage](https://codecov.io/gh/Tonejs/Tone.js) to get an idea of where more tests might be helpful.
 
 ### Synths/Effects
 

--- a/Tone/core/context/ToneWithContext.test.ts
+++ b/Tone/core/context/ToneWithContext.test.ts
@@ -5,6 +5,13 @@ import { getContext } from "../Global.js";
 import { Gain } from "./Gain.js";
 import { ToneWithContext } from "./ToneWithContext.js";
 
+/** Exposes {@link ToneWithContext._onContextRunning} for tests without `as any`. */
+class GainWithContextRunning extends Gain {
+	public triggerOnContextRunning(callback: () => void): void {
+		this._onContextRunning(callback);
+	}
+}
+
 describe("ToneWithContext", () => {
 	context("get", () => {
 		it("returns an object with all the default properties", () => {
@@ -58,9 +65,8 @@ describe("ToneWithContext", () => {
 		it("invokes the callback immediately for an offline context", () => {
 			return Offline(() => {
 				let callbackInvoked = false;
-				const gain = new Gain();
-				// Access protected method via subclass trick
-				(gain as any)._onContextRunning(() => {
+				const gain = new GainWithContextRunning();
+				gain.triggerOnContextRunning(() => {
 					callbackInvoked = true;
 				});
 				expect(callbackInvoked).to.equal(true);
@@ -70,8 +76,8 @@ describe("ToneWithContext", () => {
 
 		it("cleans up the listener on dispose", () => {
 			return Offline(() => {
-				const gain = new Gain();
-				(gain as any)._onContextRunning(() => {
+				const gain = new GainWithContextRunning();
+				gain.triggerOnContextRunning(() => {
 					// no-op
 				});
 				// Should not throw when disposing


### PR DESCRIPTION
## Summary

- Update the code coverage link in `.github/CONTRIBUTING.md` from Coveralls to **Codecov**, matching README and CI so contributors open the right dashboard.
- Refactor `ToneWithContext` tests to exercise `_onContextRunning` via a small `Gain` subclass with a public `triggerOnContextRunning` helper instead of `(gain as any)`, preserving behavior with stricter typing.

## Test plan

- [x] `npm run lint`
- [x] `npm_config_group=core npm run test` (includes `Tone/core/context/ToneWithContext.test.ts`)
- [x] `npm run test` (full suite, optional but matches CI)

