### PR TITLE
fix: TransportTime quantization issue

### DIFF
--- a/Tone/core/type/TransportTime.test.ts
+++ b/Tone/core/type/TransportTime.test.ts
@@ -131,6 +131,22 @@ describe("TransportTimeClass", () => {
 				});
 			}, 0.6);
 		});
+
+		it("returns transport time (not AudioContext time)", () => {
+			// Address #401
+			return Offline((context) => {
+				const transport = context.transport;
+				transport.start(0.1);
+				return atTime(0.69, () => {
+					expect(
+						new TransportTimeClass(context, "@4n").valueOf()
+					).to.be.closeTo(1.0, 0.01);
+					expect(
+						new TransportTimeClass(context, "@1m").valueOf()
+					).to.be.closeTo(2.0, 0.01);
+				});
+			}, 0.7);
+		});
 	});
 
 	context("Operators", () => {

--- a/Tone/core/type/TransportTime.ts
+++ b/Tone/core/type/TransportTime.ts
@@ -1,7 +1,7 @@
 import { getContext } from "../Global.js";
 import { Seconds, Ticks } from "../type/Units.js";
 import { TimeClass } from "./Time.js";
-import { TimeBaseUnit, TimeValue } from "./TimeBase.js";
+import { TimeBaseUnit, TimeExpression, TimeValue } from "./TimeBase.js";
 
 /**
  * TransportTime is a time along the Transport's
@@ -20,6 +20,26 @@ export class TransportTimeClass<
 	 */
 	protected _now(): Type {
 		return this.context.transport.seconds as Type;
+	}
+
+	protected _getExpressions(): TimeExpression<Type> {
+		const expressions = super._getExpressions();
+		// Override the quantize ("@") handler so that it returns Transport time
+		// instead of AudioContext time.
+		expressions.quantize = {
+			method: (capture: string): Type => {
+				const quantTo = new TimeClass(this.context, capture).valueOf();
+				const nextSubdivisionAudioTime =
+					this.context.transport.nextSubdivision(quantTo);
+				return this._secondsToUnits(
+					this.context.transport.getSecondsAtTime(
+						nextSubdivisionAudioTime
+					)
+				);
+			},
+			regexp: /^@(.+)/,
+		};
+		return expressions;
 	}
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,12 +14,11 @@
 		"skipLibCheck": true,
 		"moduleResolution": "Node16",
 		"strictPropertyInitialization": true,
-		"downlevelIteration": true,
 		"experimentalDecorators": true,
 		"lib": ["es6", "dom", "es2015"],
-		"baseUrl": "./",
+		"types": ["mocha", "node"],
 		"rootDir": "./"
 	},
 	"include": ["Tone/**/*.ts", "test/**/*.ts"],
-	"exclude": ["node_modules", "test/integration/**"]
+	"exclude": ["test/integration/**"]
 }


### PR DESCRIPTION
Fixes #401

Addresses issue where quantization of Transport-relative times (e.g. start in `Tone.Part`) was being resolved to AudioContext time. 