### PR TITLE
fix: Offline callbacks use OfflineContext for rendering

### DIFF
--- a/Tone/core/context/Offline.test.ts
+++ b/Tone/core/context/Offline.test.ts
@@ -1,3 +1,5 @@
+import "../clock/Transport.js";
+
 import { expect } from "chai";
 
 import { TestAudioBuffer } from "../../../test/helper/compare/TestAudioBuffer.js";
@@ -57,5 +59,23 @@ describe("Offline", () => {
 		}, 0.1);
 		const testBuff = new TestAudioBuffer(buffer.get() as AudioBuffer);
 		expect(testBuff.getTimeOfFirstSound()).to.be.closeTo(0.05, 0.0001);
+	});
+
+	it("nodes created in transport scheduleRepeat callbacks use the offline context", async () => {
+		// Addresses #781
+		// When transport callbacks fire during offline rendering, any nodes
+		// created inside them must use the offline context.
+		const buffer = await Offline(
+			({ transport }) => {
+				transport.scheduleRepeat((time) => {
+					new ToneOscillatorNode().toDestination().start(time);
+				}, 0.1);
+				transport.start(0);
+			},
+			0.5,
+			1
+		);
+		const testBuff = new TestAudioBuffer(buffer.get() as AudioBuffer);
+		expect(testBuff.isSilent()).to.equal(false);
 	});
 });

--- a/Tone/core/context/OfflineContext.ts
+++ b/Tone/core/context/OfflineContext.ts
@@ -1,5 +1,6 @@
 import { createOfflineAudioContext } from "../context/AudioContext.js";
 import { Context } from "../context/Context.js";
+import { getContext, setContext } from "../Global.js";
 import { Seconds } from "../type/Units.js";
 import { isOfflineAudioContext } from "../util/AdvancedTypeCheck.js";
 import { ToneAudioBuffer } from "./ToneAudioBuffer.js";
@@ -83,8 +84,12 @@ export class OfflineContext extends Context {
 	private async _renderClock(asynchronous: boolean): Promise<void> {
 		let index = 0;
 		while (this._duration - this._currentTime >= 0) {
-			// invoke all the callbacks on that time
+			// temporarily set this offline context as the global default
+			// so that any nodes created inside tick callbacks use this context
+			const previousContext = getContext();
+			setContext(this);
 			this.emit("tick");
+			setContext(previousContext);
 
 			// increment the clock in block-sized chunks
 			this._currentTime += 128 / this.sampleRate;


### PR DESCRIPTION
Fixes #781

Ensures that callbacks (such as `scheduleRepeat`) which are scheduled within an Offline callback all use the offline context. 