### PR TITLE
fix: Double tick trigger

### DIFF
--- a/Tone/core/clock/TickSource.test.ts
+++ b/Tone/core/clock/TickSource.test.ts
@@ -544,6 +544,65 @@ describe("TickSource", () => {
 			});
 			source.dispose();
 		});
+
+		it("does not fire duplicate ticks across consecutive windows at a tick boundary", () => {
+			// Reproduces the double-trigger bug from issues #1080/#1098/#1175.
+			// At 400 ticks/sec (equivalent to BPM=125, PPQ=192), tick 7680 falls
+			// at exactly t=19.2s.
+			const source = new TickSource(400);
+			source.start(0);
+
+			const firedTicks: number[] = [];
+			// Window 1 ends just above the tick-7680 boundary
+			source.forEachTickBetween(
+				19.19709750566994,
+				19.20000000000101,
+				(_, tick) => firedTicks.push(tick)
+			);
+			// Window 2 starts at exactly that same boundary
+			source.forEachTickBetween(
+				19.20000000000101,
+				19.202902494332076,
+				(_, tick) => firedTicks.push(tick)
+			);
+
+			const occurrences = firedTicks.filter((t) => t === 7680).length;
+			expect(occurrences).to.equal(
+				1,
+				`tick 7680 should fire exactly once, but fired ${occurrences} times`
+			);
+			source.dispose();
+		});
+
+		it("fires every tick exactly once across many consecutive windows", () => {
+			// At 2 Hz, ticks fall at 0, 0.5, 1.0, 1.5, 2.0.
+			// Window boundaries are placed just above each tick time (tick + eps)
+			// so every tick lands right at the end of one window and the start of the next.
+			const source = new TickSource(2);
+			source.start(0);
+
+			const tickCount = new Map<number, number>();
+			const record = (_: number, tick: number) => {
+				tickCount.set(tick, (tickCount.get(tick) ?? 0) + 1);
+			};
+
+			// Non-overlapping consecutive windows whose boundaries sit just above
+			// the tick times (0, 0.5, 1.0, 1.5, 2.0).
+			const eps = 1e-10;
+			source.forEachTickBetween(0, 0.5 + eps, record); // tick 0 (at 0.0) and tick 1 (at 0.5)
+			source.forEachTickBetween(0.5 + eps, 1.0 + eps, record); // tick 2 (at 1.0)
+			source.forEachTickBetween(1.0 + eps, 1.5 + eps, record); // tick 3 (at 1.5)
+			source.forEachTickBetween(1.5 + eps, 2.0 + eps, record); // tick 4 (at 2.0)
+			source.forEachTickBetween(2.0 + eps, 2.5, record); // tick 5 (at 2.5, not included)
+
+			for (const [tick, count] of tickCount) {
+				expect(count).to.equal(
+					1,
+					`tick ${tick} fired ${count} times instead of once`
+				);
+			}
+			source.dispose();
+		});
 	});
 
 	context("Seconds", () => {

--- a/Tone/core/clock/TickSource.ts
+++ b/Tone/core/clock/TickSource.ts
@@ -415,7 +415,8 @@ export class TickSource<
 
 		if (lastStateEvent && lastStateEvent.state === "started") {
 			const maxStartTime = Math.max(lastStateEvent.time, startTime);
-			// figure out the difference between the frequency ticks and the
+			// Figure out how far past the last whole-tick boundary maxStartTime
+			// sits, so we can compute the time of the next tick at or after it.
 			const startTicks = this.frequency.getTicksAtTime(maxStartTime);
 			const ticksAtStart = this.frequency.getTicksAtTime(
 				lastStateEvent.time
@@ -425,7 +426,7 @@ export class TickSource<
 			// Guard against floating-point issues: when startTicks is just barely
 			// above an integer tick boundary (offset ≈ 1), snap back to that integer
 			const firstTick = EQ(offset, 1)
-				? Math.round(startTicks)
+				? Math.floor(startTicks)
 				: startTicks + offset;
 			let nextTickTime = this.frequency.getTimeOfTick(firstTick);
 			// Advance past any ticks that land before the start of this window

--- a/Tone/core/clock/TickSource.ts
+++ b/Tone/core/clock/TickSource.ts
@@ -431,7 +431,7 @@ export class TickSource<
 			let nextTickTime = this.frequency.getTimeOfTick(firstTick);
 			// Advance past any ticks that land before the start of this window
 			// to avoid any tick that was already processed.
-			while (nextTickTime < maxStartTime) {
+			if (nextTickTime < maxStartTime) {
 				nextTickTime += this.frequency.getDurationOfTicks(
 					1,
 					nextTickTime

--- a/Tone/core/clock/TickSource.ts
+++ b/Tone/core/clock/TickSource.ts
@@ -421,12 +421,21 @@ export class TickSource<
 				lastStateEvent.time
 			);
 			const diff = startTicks - ticksAtStart;
-			let offset = Math.ceil(diff) - diff;
-			// guard against floating point issues
-			offset = EQ(offset, 1) ? 0 : offset;
-			let nextTickTime = this.frequency.getTimeOfTick(
-				startTicks + offset
-			);
+			const offset = Math.ceil(diff) - diff;
+			// Guard against floating-point issues: when startTicks is just barely
+			// above an integer tick boundary (offset ≈ 1), snap back to that integer
+			const firstTick = EQ(offset, 1)
+				? Math.round(startTicks)
+				: startTicks + offset;
+			let nextTickTime = this.frequency.getTimeOfTick(firstTick);
+			// Advance past any ticks that land before the start of this window
+			// to avoid any tick that was already processed.
+			while (nextTickTime < maxStartTime) {
+				nextTickTime += this.frequency.getDurationOfTicks(
+					1,
+					nextTickTime
+				);
+			}
 			while (nextTickTime < endTime) {
 				try {
 					callback(

--- a/Tone/core/clock/Transport.test.ts
+++ b/Tone/core/clock/Transport.test.ts
@@ -75,6 +75,20 @@ describe("Transport", () => {
 			expect(invocations).to.equal(5);
 		});
 
+		it("does not double-fire events when looping many times", async () => {
+			let invocations = 0;
+			await Offline((context) => {
+				const transport = new TransportInstance({ context });
+				transport.schedule(() => {
+					invocations++;
+				}, 0);
+				transport.setLoopPoints(0, 1).start(0);
+				transport.loop = true;
+			}, 120.1);
+			// Should fire exactly 121 times: at t=0,1,2,...,120
+			expect(invocations).to.equal(121);
+		});
+
 		it("jumps to the loopStart after the loopEnd point", async () => {
 			let looped = false;
 			await Offline((context) => {


### PR DESCRIPTION
Fixes #1098, Fixes #1175, Fixes #1080

Floating point error was making it so that the a tick could be triggered twice, essentially it would be rounded below the end of where the previous one left off leading that first event to be triggered twice. Fix is to have a while loop which steps forward to the next tick to avoid this. 