### PR TITLE
fix: Making clearInterval more efficient

### DIFF
--- a/Tone/core/context/Context.test.ts
+++ b/Tone/core/context/Context.test.ts
@@ -221,6 +221,16 @@ describe("Context", () => {
 			}, 0.05);
 		});
 
+		it("can efficiently add and remove 10k timeouts", () => {
+			const ids: number[] = [];
+			for (let i = 0; i < 10_000; i++) {
+				ids.push(ctx.setTimeout(() => {}, i * 0.001));
+			}
+			for (const id of ids) {
+				ctx.clearTimeout(id);
+			}
+		}).timeout(100);
+
 		it("is robust against altering the timeline within the callback fn", (done) => {
 			let invokeCount = 0;
 			function checkDone(id: number) {

--- a/Tone/core/context/Context.ts
+++ b/Tone/core/context/Context.ts
@@ -65,6 +65,11 @@ export class Context extends BaseContext {
 	private _timeouts: Timeline<ContextTimeoutEvent> = new Timeline();
 
 	/**
+	 * A Map from timeout ID to event for O(1) lookup in clearTimeout.
+	 */
+	private _timeoutMap = new Map<number, ContextTimeoutEvent>();
+
+	/**
 	 * The timeout id counter
 	 */
 	private _timeoutIds = 0;
@@ -554,6 +559,7 @@ export class Context extends BaseContext {
 		super.dispose();
 		this._ticker.dispose();
 		this._timeouts.dispose();
+		this._timeoutMap.clear();
 		Object.keys(this._constants).map((val) =>
 			this._constants[val].disconnect()
 		);
@@ -566,6 +572,26 @@ export class Context extends BaseContext {
 	//---------------------------
 
 	/**
+	 * Add a timeout event to the timeline and map.
+	 */
+	private _addTimeoutEvent(event: ContextTimeoutEvent): void {
+		this._timeouts.add(event);
+		this._timeoutMap.set(event.id, event);
+	}
+
+	/**
+	 * Remove a timeout event from the timeline and map.
+	 */
+	private _removeTimeoutEvent(event: ContextTimeoutEvent): void {
+		this._timeouts.remove(event);
+		// Skips the map deletion when with setInterval where the same id
+		// is reused for the next event.
+		if (this._timeoutMap.get(event.id) === event) {
+			this._timeoutMap.delete(event.id);
+		}
+	}
+
+	/**
 	 * The private loop which keeps track of the context scheduled timeouts
 	 * Is invoked from the clock source
 	 */
@@ -575,7 +601,7 @@ export class Context extends BaseContext {
 			try {
 				event.callback();
 			} finally {
-				this._timeouts.remove(event);
+				this._removeTimeoutEvent(event);
 			}
 		});
 	}
@@ -592,7 +618,7 @@ export class Context extends BaseContext {
 	setTimeout(fn: (...args: any[]) => void, timeout: Seconds): number {
 		this._timeoutIds++;
 		const now = this.now();
-		this._timeouts.add({
+		this._addTimeoutEvent({
 			callback: fn,
 			id: this._timeoutIds,
 			time: now + timeout,
@@ -605,11 +631,10 @@ export class Context extends BaseContext {
 	 * @param id The ID returned from {@link setTimeout}.
 	 */
 	clearTimeout(id: number): this {
-		this._timeouts.forEach((event) => {
-			if (event.id === id) {
-				this._timeouts.remove(event);
-			}
-		});
+		const event = this._timeoutMap.get(id);
+		if (event) {
+			this._removeTimeoutEvent(event);
+		}
 		return this;
 	}
 
@@ -631,7 +656,7 @@ export class Context extends BaseContext {
 		const id = ++this._timeoutIds;
 		const intervalFn = () => {
 			const now = this.now();
-			this._timeouts.add({
+			this._addTimeoutEvent({
 				callback: () => {
 					// invoke the callback
 					fn();

--- a/Tone/core/context/Context.ts
+++ b/Tone/core/context/Context.ts
@@ -584,7 +584,7 @@ export class Context extends BaseContext {
 	 */
 	private _removeTimeoutEvent(event: ContextTimeoutEvent): void {
 		this._timeouts.remove(event);
-		// Skips the map deletion when with setInterval where the same id
+		// Skips the map deletion in setInterval case where the same id
 		// is reused for the next event.
 		if (this._timeoutMap.get(event.id) === event) {
 			this._timeoutMap.delete(event.id);

--- a/Tone/core/util/Timeline.test.ts
+++ b/Tone/core/util/Timeline.test.ts
@@ -93,6 +93,10 @@ describe("Timeline", () => {
 			sched.remove({ time: 4 });
 		});
 		expect(sched.length).to.equal(1);
+		sched.add({ time: 1 });
+		sched.add({ time: 3 });
+		sched.remove({ time: 2 });
+		expect(sched.length).to.equal(3);
 		sched.dispose();
 	});
 

--- a/Tone/core/util/Timeline.ts
+++ b/Tone/core/util/Timeline.ts
@@ -115,7 +115,7 @@ export class Timeline<GenericEvent extends TimelineEvent> extends Tone {
 	 * @returns {Timeline} this
 	 */
 	remove(event: GenericEvent): this {
-		const index = this._timeline.indexOf(event);
+		const index = this._indexOf(event);
 		if (index !== -1) {
 			this._timeline.splice(index, 1);
 		}
@@ -240,12 +240,40 @@ export class Timeline<GenericEvent extends TimelineEvent> extends Tone {
 	 * @return The event right before the given event
 	 */
 	previousEvent(event: GenericEvent): GenericEvent | null {
-		const index = this._timeline.indexOf(event);
+		const index = this._indexOf(event);
 		if (index > 0) {
 			return this._timeline[index - 1];
 		} else {
 			return null;
 		}
+	}
+
+	/**
+	 * Return the index of the given event in the timeline. -1 if it is not found.
+	 */
+	private _indexOf(event: GenericEvent): number {
+		// Use _search since internally implemented with binary search.
+		const index = this._search(event.time);
+		if (index === -1) {
+			return -1;
+		}
+		// There may be multiple events with the same time, so find the exact event
+		// Search forward and backward for events with the same time
+		for (let i = index; i < this._timeline.length; i++) {
+			if (this._timeline[i] === event) {
+				return i;
+			} else if (this._timeline[i].time !== event.time) {
+				break;
+			}
+		}
+		for (let j = index - 1; j >= 0; j--) {
+			if (this._timeline[j] === event) {
+				return j;
+			} else if (this._timeline[j].time !== event.time) {
+				break;
+			}
+		}
+		return -1;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1168

Adds two optimizations to boost the efficiency of Context.clearInterval and Context.clearTimeout

1. creates a private _timeoutMap which maps ids to events so that clearInterval does not need to iterate over all of the tiemout events to find the right one. 
2. Uses binary search within the timeline remove event instead of indexOf so that it could more quickly find the correct event. 

Both combined gave me a very noticeable 60x speed up compared to the old implementation. 