### PR TITLE
fix: Checking for circular dependencies

### DIFF
--- a/Tone/core/Global.test.ts
+++ b/Tone/core/Global.test.ts
@@ -1,0 +1,19 @@
+import { expect } from "chai";
+
+import { Context } from "./context/Context.js";
+import { getContext, setContext } from "./Global.js";
+
+describe("Global", () => {
+	it("can setContext with disposeOld = true", () => {
+		const origContext = getContext();
+		const toneContext = new Context();
+
+		setContext(toneContext);
+		expect(getContext()).to.equal(toneContext);
+
+		setContext(origContext, true);
+
+		expect(getContext()).to.equal(origContext);
+		expect(toneContext.disposed).to.be.true;
+	});
+});

--- a/Tone/core/Global.ts
+++ b/Tone/core/Global.ts
@@ -1,39 +1,18 @@
 import { version } from "../version.js";
-import {
-	AnyAudioContext,
-	hasAudioContext,
-	theWindow,
-} from "./context/AudioContext.js";
+import { AnyAudioContext, theWindow } from "./context/AudioContext.js";
 import { BaseContext } from "./context/BaseContext.js";
 import { Context } from "./context/Context.js";
-import { DummyContext } from "./context/DummyContext.js";
+import {
+	getContext,
+	setContext as _setContext,
+} from "./context/GlobalContext.js";
 import { OfflineContext } from "./context/OfflineContext.js";
 import {
 	isAudioContext,
 	isOfflineAudioContext,
 } from "./util/AdvancedTypeCheck.js";
 
-/**
- * This dummy context is used to avoid throwing immediate errors when importing in Node.js
- */
-const dummyContext = new DummyContext();
-
-/**
- * The global audio context which is getable and assignable through
- * getContext and setContext
- */
-let globalContext: BaseContext = dummyContext;
-
-/**
- * Returns the default system-wide {@link Context}
- * @category Core
- */
-export function getContext(): BaseContext {
-	if (globalContext === dummyContext && hasAudioContext) {
-		setContext(new Context());
-	}
-	return globalContext;
-}
+export { getContext };
 
 /**
  * Set the default audio context
@@ -46,15 +25,15 @@ export function setContext(
 	disposeOld = false
 ): void {
 	if (disposeOld) {
-		globalContext.dispose();
+		getContext().dispose();
 	}
 
 	if (isAudioContext(context)) {
-		globalContext = new Context(context);
+		_setContext(new Context(context));
 	} else if (isOfflineAudioContext(context)) {
-		globalContext = new OfflineContext(context);
+		_setContext(new OfflineContext(context));
 	} else {
-		globalContext = context;
+		_setContext(context);
 	}
 }
 
@@ -72,7 +51,7 @@ export function setContext(
  * @category Core
  */
 export function start(): Promise<void> {
-	return globalContext.resume();
+	return getContext().resume();
 }
 
 /**

--- a/Tone/core/context/GlobalContext.ts
+++ b/Tone/core/context/GlobalContext.ts
@@ -9,9 +9,8 @@ import { DummyContext } from "./DummyContext.js";
 export const dummyContext: BaseContext = new DummyContext();
 
 /**
- * The global audio context storage. Shared between Global.ts (which adds
- * native-context wrapping) and context files (OfflineContext, ToneAudioBuffer)
- * that need access to the current context without creating a circular dependency.
+ * The global audio context which is getable and assignable through
+ * getContext and setContext
  */
 let globalContext: BaseContext = dummyContext;
 

--- a/Tone/core/context/GlobalContext.ts
+++ b/Tone/core/context/GlobalContext.ts
@@ -1,0 +1,35 @@
+import { hasAudioContext } from "./AudioContext.js";
+import { BaseContext } from "./BaseContext.js";
+import { Context } from "./Context.js";
+import { DummyContext } from "./DummyContext.js";
+
+/**
+ * This dummy context is used to avoid throwing immediate errors when importing in Node.js
+ */
+export const dummyContext: BaseContext = new DummyContext();
+
+/**
+ * The global audio context storage. Shared between Global.ts (which adds
+ * native-context wrapping) and context files (OfflineContext, ToneAudioBuffer)
+ * that need access to the current context without creating a circular dependency.
+ */
+let globalContext: BaseContext = dummyContext;
+
+/**
+ * Returns the default system-wide {@link Context}.
+ * Auto-initializes a real Context in browser environments.
+ */
+export function getContext(): BaseContext {
+	if (globalContext === dummyContext && hasAudioContext) {
+		globalContext = new Context();
+	}
+	return globalContext;
+}
+
+/**
+ * Set the global context directly. Unlike the richer `setContext` in Global.ts,
+ * this only accepts a {@link BaseContext} — no native AudioContext wrapping.
+ */
+export function setContext(context: BaseContext): void {
+	globalContext = context;
+}

--- a/Tone/core/context/OfflineContext.ts
+++ b/Tone/core/context/OfflineContext.ts
@@ -1,8 +1,8 @@
 import { createOfflineAudioContext } from "../context/AudioContext.js";
 import { Context } from "../context/Context.js";
-import { getContext, setContext } from "../Global.js";
 import { Seconds } from "../type/Units.js";
 import { isOfflineAudioContext } from "../util/AdvancedTypeCheck.js";
+import { getContext, setContext } from "./GlobalContext.js";
 import { ToneAudioBuffer } from "./ToneAudioBuffer.js";
 
 /**

--- a/Tone/core/context/ToneAudioBuffer.ts
+++ b/Tone/core/context/ToneAudioBuffer.ts
@@ -1,10 +1,10 @@
-import { getContext } from "../Global.js";
 import { Tone } from "../Tone.js";
 import { Samples, Seconds } from "../type/Units.js";
 import { assert } from "../util/Debug.js";
 import { optionsFromArguments } from "../util/Defaults.js";
 import { noOp } from "../util/Interface.js";
 import { isArray, isNumber, isString } from "../util/TypeCheck.js";
+import { getContext } from "./GlobalContext.js";
 
 interface ToneAudioBufferOptions {
 	url?: string | AudioBuffer | ToneAudioBuffer;

--- a/test/integration/rollup/index.js
+++ b/test/integration/rollup/index.js
@@ -1,0 +1,3 @@
+import { MonoSynth } from "tone";
+
+const synth = new MonoSynth();

--- a/test/integration/rollup/package.json
+++ b/test/integration/rollup/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "tone-rollup-test",
+	"type": "module",
+	"dependencies": {
+		"@rollup/plugin-node-resolve": "^15.2.3",
+		"tone": "file:../../..",
+		"rollup": "^4.18.0"
+	},
+	"scripts": {
+		"test": "rollup --config rollup.config.mjs"
+	}
+}

--- a/test/integration/rollup/rollup.config.mjs
+++ b/test/integration/rollup/rollup.config.mjs
@@ -1,0 +1,17 @@
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+
+/** @type {import('rollup').RollupOptions} */
+export default {
+	input: "index.js",
+	output: {
+		file: "dist/bundle.js",
+		format: "esm",
+	},
+	plugins: [nodeResolve()],
+	onwarn(warning, warn) {
+		if (warning.code === "CIRCULAR_DEPENDENCY") {
+			throw new Error(`Circular dependency detected: ${warning.message}`);
+		}
+		warn(warning);
+	},
+};


### PR DESCRIPTION
Fixes #1088 

Adds a rollup validation test and also checks for circular dependencies. Moves set/getContext into GlobalContext.ts so that it can be used internally. 