### PR TITLE
feat: Analyzer template to infer channel count from constructor

### DIFF
--- a/Tone/component/analysis/Analyser.test.ts
+++ b/Tone/component/analysis/Analyser.test.ts
@@ -71,7 +71,7 @@ describe("Analyser", () => {
 			size: 512,
 		});
 		expect(anl.getValue().length).to.equal(2);
-		expect((anl.getValue()[0] as Float32Array).length).to.equal(512);
+		expect(anl.getValue()[0].length).to.equal(512);
 		anl.dispose();
 	});
 });

--- a/Tone/component/analysis/Analyser.ts
+++ b/Tone/component/analysis/Analyser.ts
@@ -56,7 +56,7 @@ export class Analyser<ChannelCount extends number = 1> extends ToneAudioNode<
 	/**
 	 * The buffer that the FFT data is written to
 	 */
-	private _buffers: Float32Array<ArrayBuffer>[] = [];
+	private _buffers: Float32Array[] = [];
 
 	/**
 	 * @param type The return type of the analysis, either "fft", or "waveform".

--- a/Tone/component/analysis/Analyser.ts
+++ b/Tone/component/analysis/Analyser.ts
@@ -12,11 +12,12 @@ import { Split } from "../channel/Split.js";
 
 export type AnalyserType = "fft" | "waveform";
 
-export interface AnalyserOptions extends ToneAudioNodeOptions {
+export interface AnalyserOptions<ChannelCount extends number>
+	extends ToneAudioNodeOptions {
 	size: PowerOfTwo;
 	type: AnalyserType;
 	smoothing: NormalRange;
-	channels: number;
+	channels: ChannelCount;
 }
 
 /**
@@ -24,7 +25,9 @@ export interface AnalyserOptions extends ToneAudioNodeOptions {
  * Extracts FFT or Waveform data from the incoming signal.
  * @category Component
  */
-export class Analyser extends ToneAudioNode<AnalyserOptions> {
+export class Analyser<ChannelCount extends number = 1> extends ToneAudioNode<
+	AnalyserOptions<ChannelCount>
+> {
 	readonly name: string = "Analyser";
 
 	readonly input: InputNode;
@@ -53,14 +56,14 @@ export class Analyser extends ToneAudioNode<AnalyserOptions> {
 	/**
 	 * The buffer that the FFT data is written to
 	 */
-	private _buffers: Float32Array[] = [];
+	private _buffers: Float32Array<ArrayBuffer>[] = [];
 
 	/**
 	 * @param type The return type of the analysis, either "fft", or "waveform".
 	 * @param size The size of the FFT. This must be a power of two in the range 16 to 16384.
 	 */
 	constructor(type?: AnalyserType, size?: number);
-	constructor(options?: Partial<AnalyserOptions>);
+	constructor(options?: Partial<AnalyserOptions<ChannelCount>>);
 	constructor() {
 		const options = optionsFromArguments(
 			Analyser.getDefaults(),
@@ -93,12 +96,12 @@ export class Analyser extends ToneAudioNode<AnalyserOptions> {
 		this.smoothing = options.smoothing;
 	}
 
-	static getDefaults(): AnalyserOptions {
+	static getDefaults(): AnalyserOptions<1> {
 		return Object.assign(ToneAudioNode.getDefaults(), {
 			size: 1024,
 			smoothing: 0.8,
 			type: "fft" as AnalyserType,
-			channels: 1,
+			channels: 1 as const,
 		});
 	}
 
@@ -108,7 +111,7 @@ export class Analyser extends ToneAudioNode<AnalyserOptions> {
 	 * return an array of Float32Arrays where each index in the array
 	 * represents the analysis done on a channel.
 	 */
-	getValue(): Float32Array | Float32Array[] {
+	getValue(): ChannelCount extends 1 ? Float32Array : Float32Array[] {
 		this._analyzers.forEach((analyser, index) => {
 			const buffer = this._buffers[index];
 			if (this._type === "fft") {
@@ -118,9 +121,13 @@ export class Analyser extends ToneAudioNode<AnalyserOptions> {
 			}
 		});
 		if (this.channels === 1) {
-			return this._buffers[0];
+			return this._buffers[0] as ChannelCount extends 1
+				? Float32Array
+				: Float32Array[];
 		} else {
-			return this._buffers;
+			return this._buffers as ChannelCount extends 1
+				? Float32Array
+				: Float32Array[];
 		}
 	}
 
@@ -141,8 +148,8 @@ export class Analyser extends ToneAudioNode<AnalyserOptions> {
 	 * The number of channels the analyser does the analysis on. Channel
 	 * separation is done using {@link Split}
 	 */
-	get channels(): number {
-		return this._analyzers.length;
+	get channels(): ChannelCount {
+		return this._analyzers.length as ChannelCount;
 	}
 
 	/**

--- a/Tone/component/analysis/DCMeter.ts
+++ b/Tone/component/analysis/DCMeter.ts
@@ -17,7 +17,7 @@ export type DCMeterOptions = MeterBaseOptions;
  * const level = meter.getValue();
  * @category Component
  */
-export class DCMeter extends MeterBase<DCMeterOptions> {
+export class DCMeter extends MeterBase<DCMeterOptions, 1> {
 	readonly name: string = "DCMeter";
 
 	constructor(options?: Partial<DCMeterOptions>);

--- a/Tone/component/analysis/FFT.ts
+++ b/Tone/component/analysis/FFT.ts
@@ -16,7 +16,7 @@ export interface FFTOptions extends MeterBaseOptions {
  * Read more about FFT algorithms on [Wikipedia] (https://en.wikipedia.org/wiki/Fast_Fourier_transform).
  * @category Component
  */
-export class FFT extends MeterBase<FFTOptions> {
+export class FFT extends MeterBase<FFTOptions, 1> {
 	readonly name: string = "FFT";
 
 	/**
@@ -55,7 +55,7 @@ export class FFT extends MeterBase<FFTOptions> {
 	 * Returns the frequency data of length {@link size} as a Float32Array of decibel values.
 	 */
 	getValue(): Float32Array {
-		const values = this._analyser.getValue() as Float32Array;
+		const values = this._analyser.getValue();
 		return values.map((v) => (this.normalRange ? dbToGain(v) : v));
 	}
 

--- a/Tone/component/analysis/Meter.test.ts
+++ b/Tone/component/analysis/Meter.test.ts
@@ -30,7 +30,7 @@ describe("Meter", () => {
 			const meter = new Meter({
 				channelCount: 4,
 			});
-			expect((meter.getValue() as number[]).length).to.equal(4);
+			expect(meter.getValue().length).to.equal(4);
 			meter.dispose();
 		});
 

--- a/Tone/component/analysis/Meter.ts
+++ b/Tone/component/analysis/Meter.ts
@@ -5,10 +5,11 @@ import { optionsFromArguments } from "../../core/util/Defaults.js";
 import { Analyser } from "./Analyser.js";
 import { MeterBase, MeterBaseOptions } from "./MeterBase.js";
 
-export interface MeterOptions extends MeterBaseOptions {
+export interface MeterOptions<ChannelCount extends number>
+	extends MeterBaseOptions {
 	smoothing: NormalRange;
 	normalRange: boolean;
-	channelCount: number;
+	channelCount: ChannelCount;
 }
 
 /**
@@ -29,7 +30,10 @@ export interface MeterOptions extends MeterBaseOptions {
  * setInterval(() => console.log(meter.getValue()), 100);
  * @category Component
  */
-export class Meter extends MeterBase<MeterOptions> {
+export class Meter<ChannelCount extends number = 1> extends MeterBase<
+	MeterOptions<ChannelCount>,
+	ChannelCount
+> {
 	readonly name: string = "Meter";
 
 	/**
@@ -53,7 +57,7 @@ export class Meter extends MeterBase<MeterOptions> {
 	 * @param smoothing The amount of smoothing applied between frames.
 	 */
 	constructor(smoothing?: NormalRange);
-	constructor(options?: Partial<MeterOptions>);
+	constructor(options?: Partial<MeterOptions<ChannelCount>>);
 	constructor() {
 		const options = optionsFromArguments(Meter.getDefaults(), arguments, [
 			"smoothing",
@@ -67,7 +71,7 @@ export class Meter extends MeterBase<MeterOptions> {
 					context: this.context,
 					size: 256,
 					type: "waveform",
-					channels: options.channelCount,
+					channels: options.channelCount as ChannelCount,
 				});
 
 		this.smoothing = options.smoothing;
@@ -76,11 +80,11 @@ export class Meter extends MeterBase<MeterOptions> {
 		this._rms.fill(0);
 	}
 
-	static getDefaults(): MeterOptions {
+	static getDefaults(): MeterOptions<1> {
 		return Object.assign(MeterBase.getDefaults(), {
 			smoothing: 0.8,
 			normalRange: false,
-			channelCount: 1,
+			channelCount: 1 as const,
 		});
 	}
 
@@ -105,7 +109,7 @@ export class Meter extends MeterBase<MeterOptions> {
 	 * representing the value of the input signal. When {@link channels} > 1,
 	 * then each channel is returned as a value in a number array.
 	 */
-	getValue(): number | number[] {
+	getValue(): ChannelCount extends 1 ? number : number[] {
 		const aValues = this._analyser.getValue();
 		const channelValues =
 			this.channels === 1
@@ -132,16 +136,16 @@ export class Meter extends MeterBase<MeterOptions> {
 				: gainToDb(this._rms[channel]);
 		});
 		if (this.channels === 1) {
-			return vals[0];
+			return vals[0] as ChannelCount extends 1 ? number : number[];
 		} else {
-			return vals;
+			return vals as ChannelCount extends 1 ? number : number[];
 		}
 	}
 
 	/**
 	 * The number of channels of analysis.
 	 */
-	get channels(): number {
+	get channels(): ChannelCount {
 		return this._analyser.channels;
 	}
 

--- a/Tone/component/analysis/MeterBase.ts
+++ b/Tone/component/analysis/MeterBase.ts
@@ -14,6 +14,7 @@ export type MeterBaseOptions = ToneAudioNodeOptions;
  */
 export class MeterBase<
 	Options extends MeterBaseOptions,
+	ChannelCount extends number,
 > extends ToneAudioNode<Options> {
 	readonly name: string = "MeterBase";
 
@@ -30,7 +31,7 @@ export class MeterBase<
 	/**
 	 * The analyser node for the incoming signal
 	 */
-	protected _analyser: Analyser;
+	protected _analyser: Analyser<ChannelCount>;
 
 	constructor(options?: Partial<MeterBaseOptions>);
 	constructor() {
@@ -39,7 +40,7 @@ export class MeterBase<
 		this.input =
 			this.output =
 			this._analyser =
-				new Analyser({
+				new Analyser<ChannelCount>({
 					context: this.context,
 					size: 256,
 					type: "waveform",

--- a/Tone/component/analysis/Waveform.ts
+++ b/Tone/component/analysis/Waveform.ts
@@ -13,7 +13,7 @@ export interface WaveformOptions extends MeterBaseOptions {
  * Get the current waveform data of the connected audio source.
  * @category Component
  */
-export class Waveform extends MeterBase<WaveformOptions> {
+export class Waveform extends MeterBase<WaveformOptions, 1> {
 	readonly name: string = "Waveform";
 
 	/**
@@ -44,7 +44,7 @@ export class Waveform extends MeterBase<WaveformOptions> {
 	 * represents a sample in the waveform.
 	 */
 	getValue(): Float32Array {
-		return this._analyser.getValue() as Float32Array;
+		return this._analyser.getValue();
 	}
 
 	/**


### PR DESCRIPTION
Instead of having `getValue` return either an array or a single float32, infers the correct type using the constructor args. 