### PR TITLE
fix(tests): prevent `only` in tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import stylisticJs from "@stylistic/eslint-plugin-js";
 import stylisticTs from "@stylistic/eslint-plugin-ts";
 import html from "eslint-plugin-html";
 import jsdoc from "eslint-plugin-jsdoc";
+import noOnlyTests from "eslint-plugin-no-only-tests";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 import unusedImports from "eslint-plugin-unused-imports";
 import tseslint from "typescript-eslint";
@@ -17,11 +18,13 @@ const customConfig = {
 		html,
 		"simple-import-sort": simpleImportSort,
 		"unused-imports": unusedImports,
+		"no-only-tests": noOnlyTests,
 	},
 	rules: {
 		"@typescript-eslint/array-type": "off",
 		"@typescript-eslint/ban-ts-comment": "off",
 		"@typescript-eslint/ban-ts-ignore": "off",
+		"no-only-tests/no-only-tests": "error",
 		"jsdoc/check-alignment": 1,
 		"jsdoc/check-indentation": [
 			"error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
 				"eslint": "^9.25.1",
 				"eslint-plugin-html": "^8.1.2",
 				"eslint-plugin-jsdoc": "^50.6.11",
+				"eslint-plugin-no-only-tests": "^3.4.0",
 				"eslint-plugin-simple-import-sort": "^12.1.1",
 				"eslint-plugin-unused-imports": "^4.1.4",
 				"fft-windowing": "^0.1.4",
@@ -6723,6 +6724,16 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-plugin-no-only-tests": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.4.0.tgz",
+			"integrity": "sha512-4S3/9Nb7A2tiMcpzEQE9bQSlpeOz6WJkgryBuou/SA8W2x2c8Zf4j0NvTKBjv6qNhF9T79tmkecm/0CHqV0UGg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=5.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-simple-import-sort": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
 		"eslint": "^9.25.1",
 		"eslint-plugin-html": "^8.1.2",
 		"eslint-plugin-jsdoc": "^50.6.11",
+		"eslint-plugin-no-only-tests": "^3.4.0",
 		"eslint-plugin-simple-import-sort": "^12.1.1",
 		"eslint-plugin-unused-imports": "^4.1.4",
 		"fft-windowing": "^0.1.4",


### PR DESCRIPTION
Keeps test debugging code from making it into the final repo. Thanks @HURRAEY for bringing this to my attention. 