### PR TITLE
test(context): relax bulk timeout budget

### DIFF
--- a/Tone/core/context/Context.test.ts
+++ b/Tone/core/context/Context.test.ts
@@ -229,7 +229,7 @@ describe("Context", () => {
 			for (const id of ids) {
 				ctx.clearTimeout(id);
 			}
-		}).timeout(100);
+		}).timeout(500);
 
 		it("is robust against altering the timeline within the callback fn", (done) => {
 			let invokeCount = 0;


### PR DESCRIPTION
## Summary

- Increase the Mocha timeout for the `Context` bulk timeout add/remove test from 100ms to 500ms.
- Keep the existing 10k timeout add/remove coverage while reducing false failures on slower browser or OS combinations.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx eslint Tone/core/context/Context.test.ts`
- [x] `npm run lint` in an LF checkout
- [x] `npx tsc`
- [x] `npx web-test-runner --config=./test/web-test-runner.config.js --coverage --group core`
- [x] `npx web-test-runner --config=./test/web-test-runner.config.js --coverage --group core --concurrency 1`