### PR TITLE
chore: updating to version 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: 22.12.0
+                  node-version: 24
                   cache: "npm"
 
             - name: Install dependencies
@@ -76,7 +76,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: 22.12.0
+                  node-version: 24
                   registry-url: "https://registry.npmjs.org"
                   cache: "npm"
 


### PR DESCRIPTION
i think it's required to do the type of OICD builds that i'm using in release.yml