### PR TITLE
chore: queuing up releases so they don't run concurrently

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ on:
         types:
             - completed
 
+concurrency:
+    group: releases
+    cancel-in-progress: false
+    queue: max
+
 jobs:
     bump:
         name: Bump version and update changelog


### PR DESCRIPTION
Avoiding any issues with merge issues when modifying the CHANGELOG and npm package numbers in the release step