### PR TITLE
fix(PatternGenerator): keep randomWalk within the value range

### DIFF
--- a/Tone/event/PatternGenerator.test.ts
+++ b/Tone/event/PatternGenerator.test.ts
@@ -99,5 +99,23 @@ describe("PatternGenerator", () => {
 				currentIndex = nextIndex;
 			}
 		});
+
+		it("never randomly walks outside of the range of values", () => {
+			[1, 2, 3, 4].forEach((numValues) => {
+				const pattern = PatternGenerator(numValues, "randomWalk");
+				for (let i = 0; i < 100; i++) {
+					expect(pattern.next().value)
+						.to.be.at.least(0)
+						.and.at.most(numValues - 1);
+				}
+			});
+		});
+
+		it("randomly walks in place when there is only one value", () => {
+			const pattern = PatternGenerator(1, "randomWalk");
+			expect(getArrayValues(pattern, 10)).to.deep.equal([
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			]);
+		});
 	});
 });

--- a/Tone/event/PatternGenerator.ts
+++ b/Tone/event/PatternGenerator.ts
@@ -138,15 +138,18 @@ function* randomWalk(numValues: number): IterableIterator<number> {
 	// randomly choose a starting index
 	let index = Math.floor(Math.random() * numValues);
 	while (true) {
-		if (index === 0) {
-			index++; // at bottom, so force upward step
-		} else if (index === numValues - 1) {
-			index--; // at top, so force downward step
-		} else if (Math.random() < 0.5) {
-			// else choose random downward or upward step
-			index--;
-		} else {
-			index++;
+		// with a single value there is nowhere to step to
+		if (numValues > 1) {
+			if (index === 0) {
+				index++; // at bottom, so force upward step
+			} else if (index === numValues - 1) {
+				index--; // at top, so force downward step
+			} else if (Math.random() < 0.5) {
+				// else choose random downward or upward step
+				index--;
+			} else {
+				index++;
+			}
 		}
 		yield index;
 	}


### PR DESCRIPTION
### The bug

`randomWalk` is the only pattern generator that doesn't bound its index, and with a single value it walks straight off the end of the array and never comes back:

```js
const pattern = PatternGenerator(1, "randomWalk");
// yields 1, 2, 1, 0, 1, 2, 3, 4, 5, 6, 7, 8, …
// 0 is the only valid index
```

Index 0 is both the bottom and the top of a one-value range. The bottom check comes first, so it wins and steps up to 1. From there neither boundary check can ever match again — `index === 0` is false, and `index === numValues - 1` is the same test — so every following step is an unguarded random ±1 with nothing above it.

Through the public API that means a one-value `Tone.Pattern` hands `undefined` to its callback on almost every tick, since `_tick` does `this._values[index.value]`:

```js
const pattern = new Tone.Pattern(
	(time, note) => {
		// note is undefined
		synth.triggerAttackRelease(note, 0.1, time);
	},
	["C4"],
	"randomWalk"
).start(0);
```

A single-value array is legal — `PatternGenerator` only asserts `numValues >= 1` — and it is easy to land on when `values` comes from data and is assigned at runtime.

### The fix

Hold the index still when there is nowhere to step to. Every other generator already pins to 0 for a single value through `clamp(index, 0, numValues - 1)`, so this just brings `randomWalk` in line with its neighbours. For two or more values the walk is unchanged.

### Tests

Two tests added next to the existing `randomWalk` test:

- `never randomly walks outside of the range of values` — asserts the invariant the bug broke, over sizes 1 through 4.
- `randomly walks in place when there is only one value` — deterministic, expects ten `0`s.

The existing `randomWalk` test can't catch this: it uses five values and only asserts that consecutive indices differ by 1, which stays true while the walk is drifting past the end of the array.

Both new tests fail on `dev` and pass with the change. Before the fix:

```
❌ PatternGenerator > Patterns > randomly walks in place when there is only one value
      AssertionError: expected [ 1, +0, 1, +0, 1, 2, 3, 2, 1, +0 ] to deeply equal [ Array(10) ]
```

### Verification

`npm test` for the `event` group, which covers the changed file — 6/6 test files, 182 passing, 0 failing (180 before the two new tests). `npm run lint` and `npm run spellcheck` are both clean, and prettier reports no formatting changes. I couldn't get a single-browser run of all 145 test files to finish on this machine — it wedges partway through with unrelated `Clock`/`TickSource` timing failures that don't reproduce when that group runs on its own — so the remaining groups are covered by CI here rather than locally.
