### PR TITLE
Fix: construct Listener AudioParams lazily

### DIFF
--- a/Tone/core/context/Listener.test.ts
+++ b/Tone/core/context/Listener.test.ts
@@ -2,6 +2,8 @@ import { expect } from "chai";
 
 import { Offline } from "../../../test/helper/Offline.js";
 import { getContext } from "../Global.js";
+import { AnyAudioContext } from "./AudioContext.js";
+import { DummyContext } from "./DummyContext.js";
 import { ListenerInstance } from "./Listener.js";
 
 describe("Listener", () => {
@@ -18,5 +20,22 @@ describe("Listener", () => {
 			expect(listener.get()).to.have.property("forwardZ");
 			expect(listener.get()).to.have.property("upY");
 		});
+	});
+
+	it("can be constructed on a context whose native AudioListener has no position/forward/up AudioParams (e.g. Firefox)", () => {
+		// Firefox implements no positionX/Y/Z, forwardX/Y/Z, or upX/Y/Z
+		// AudioParams on AudioListener (see MDN browser-compat-data). Wrapping
+		// them eagerly used to throw "param must be an AudioParam" as soon as
+		// a consumer passed such a context into Tone.setContext().
+		class NoListenerParamsContext extends DummyContext {
+			get rawContext(): AnyAudioContext {
+				return { listener: {} } as AnyAudioContext;
+			}
+		}
+
+		expect(
+			() =>
+				new ListenerInstance({ context: new NoListenerParamsContext() })
+		).to.not.throw();
 	});
 });

--- a/Tone/core/context/Listener.test.ts
+++ b/Tone/core/context/Listener.test.ts
@@ -38,4 +38,22 @@ describe("Listener", () => {
 				new ListenerInstance({ context: new NoListenerParamsContext() })
 		).to.not.throw();
 	});
+
+	it("can get() and set() on a context whose native AudioListener has no position/forward/up AudioParams (e.g. Firefox)", () => {
+		// get()/set() (inherited from ToneWithContext) duck-type each
+		// property via `this[attribute]`, which used to force the lazy
+		// getters above to construct -- and throw -- even on the exact
+		// context the previous test constructs the Listener on.
+		class NoListenerParamsContext extends DummyContext {
+			get rawContext(): AnyAudioContext {
+				return { listener: {} } as AnyAudioContext;
+			}
+		}
+
+		const listener = new ListenerInstance({
+			context: new NoListenerParamsContext(),
+		});
+		expect(() => listener.get()).to.not.throw();
+		expect(() => listener.set({ positionX: 1 })).to.not.throw();
+	});
 });

--- a/Tone/core/context/Listener.ts
+++ b/Tone/core/context/Listener.ts
@@ -30,50 +30,113 @@ export class ListenerInstance extends ToneAudioNode<ListenerOptions> {
 	output: undefined;
 	input: undefined;
 
-	readonly positionX: Param = new Param({
-		context: this.context,
-		param: this.context.rawContext.listener.positionX,
-	});
+	/**
+	 * The nine AudioListener params are constructed lazily, on first access,
+	 * instead of eagerly in the constructor. Some browsers (e.g. Firefox) don't
+	 * implement the AudioListener position/forward/up AudioParams, which makes
+	 * wrapping them in a Param throw immediately when a consumer passes in
+	 * their own native AudioContext via Tone.setContext(). Apps that never
+	 * touch 3D spatialization can still use such a context as long as these
+	 * getters are never called.
+	 */
+	private _positionX?: Param;
+	get positionX(): Param {
+		if (!this._positionX) {
+			this._positionX = new Param({
+				context: this.context,
+				param: this.context.rawContext.listener.positionX,
+			});
+		}
+		return this._positionX;
+	}
 
-	readonly positionY: Param = new Param({
-		context: this.context,
-		param: this.context.rawContext.listener.positionY,
-	});
+	private _positionY?: Param;
+	get positionY(): Param {
+		if (!this._positionY) {
+			this._positionY = new Param({
+				context: this.context,
+				param: this.context.rawContext.listener.positionY,
+			});
+		}
+		return this._positionY;
+	}
 
-	readonly positionZ: Param = new Param({
-		context: this.context,
-		param: this.context.rawContext.listener.positionZ,
-	});
+	private _positionZ?: Param;
+	get positionZ(): Param {
+		if (!this._positionZ) {
+			this._positionZ = new Param({
+				context: this.context,
+				param: this.context.rawContext.listener.positionZ,
+			});
+		}
+		return this._positionZ;
+	}
 
-	readonly forwardX: Param = new Param({
-		context: this.context,
-		param: this.context.rawContext.listener.forwardX,
-	});
+	private _forwardX?: Param;
+	get forwardX(): Param {
+		if (!this._forwardX) {
+			this._forwardX = new Param({
+				context: this.context,
+				param: this.context.rawContext.listener.forwardX,
+			});
+		}
+		return this._forwardX;
+	}
 
-	readonly forwardY: Param = new Param({
-		context: this.context,
-		param: this.context.rawContext.listener.forwardY,
-	});
+	private _forwardY?: Param;
+	get forwardY(): Param {
+		if (!this._forwardY) {
+			this._forwardY = new Param({
+				context: this.context,
+				param: this.context.rawContext.listener.forwardY,
+			});
+		}
+		return this._forwardY;
+	}
 
-	readonly forwardZ: Param = new Param({
-		context: this.context,
-		param: this.context.rawContext.listener.forwardZ,
-	});
+	private _forwardZ?: Param;
+	get forwardZ(): Param {
+		if (!this._forwardZ) {
+			this._forwardZ = new Param({
+				context: this.context,
+				param: this.context.rawContext.listener.forwardZ,
+			});
+		}
+		return this._forwardZ;
+	}
 
-	readonly upX: Param = new Param({
-		context: this.context,
-		param: this.context.rawContext.listener.upX,
-	});
+	private _upX?: Param;
+	get upX(): Param {
+		if (!this._upX) {
+			this._upX = new Param({
+				context: this.context,
+				param: this.context.rawContext.listener.upX,
+			});
+		}
+		return this._upX;
+	}
 
-	readonly upY: Param = new Param({
-		context: this.context,
-		param: this.context.rawContext.listener.upY,
-	});
+	private _upY?: Param;
+	get upY(): Param {
+		if (!this._upY) {
+			this._upY = new Param({
+				context: this.context,
+				param: this.context.rawContext.listener.upY,
+			});
+		}
+		return this._upY;
+	}
 
-	readonly upZ: Param = new Param({
-		context: this.context,
-		param: this.context.rawContext.listener.upZ,
-	});
+	private _upZ?: Param;
+	get upZ(): Param {
+		if (!this._upZ) {
+			this._upZ = new Param({
+				context: this.context,
+				param: this.context.rawContext.listener.upZ,
+			});
+		}
+		return this._upZ;
+	}
 
 	static getDefaults(): ListenerOptions {
 		return Object.assign(ToneAudioNode.getDefaults(), {
@@ -91,15 +154,15 @@ export class ListenerInstance extends ToneAudioNode<ListenerOptions> {
 
 	dispose(): this {
 		super.dispose();
-		this.positionX.dispose();
-		this.positionY.dispose();
-		this.positionZ.dispose();
-		this.forwardX.dispose();
-		this.forwardY.dispose();
-		this.forwardZ.dispose();
-		this.upX.dispose();
-		this.upY.dispose();
-		this.upZ.dispose();
+		this._positionX?.dispose();
+		this._positionY?.dispose();
+		this._positionZ?.dispose();
+		this._forwardX?.dispose();
+		this._forwardY?.dispose();
+		this._forwardZ?.dispose();
+		this._upX?.dispose();
+		this._upY?.dispose();
+		this._upZ?.dispose();
 		return this;
 	}
 }

--- a/Tone/core/context/Listener.ts
+++ b/Tone/core/context/Listener.ts
@@ -1,3 +1,5 @@
+import { isAudioParam } from "../util/AdvancedTypeCheck.js";
+import { RecursivePartial } from "../util/Interface.js";
 import { onContextClose, onContextInit } from "./ContextInitialization.js";
 import { Param } from "./Param.js";
 import { ToneAudioNode, ToneAudioNodeOptions } from "./ToneAudioNode.js";
@@ -31,6 +33,17 @@ export class ListenerInstance extends ToneAudioNode<ListenerOptions> {
 	input: undefined;
 
 	/**
+	 * True if this context's native AudioListener implements the
+	 * position/forward/up AudioParams (see the comment on positionX below).
+	 * Computed once and used by get()/set() so that they can skip these nine
+	 * properties instead of forcing -- and throwing on -- the lazy getters.
+	 */
+	private readonly _hasPositionParams: boolean = isAudioParam(
+		this.context.rawContext.listener.positionX
+	);
+
+	private _positionX?: Param;
+	/**
 	 * The nine AudioListener params are constructed lazily, on first access,
 	 * instead of eagerly in the constructor. Some browsers (e.g. Firefox) don't
 	 * implement the AudioListener position/forward/up AudioParams, which makes
@@ -39,7 +52,6 @@ export class ListenerInstance extends ToneAudioNode<ListenerOptions> {
 	 * touch 3D spatialization can still use such a context as long as these
 	 * getters are never called.
 	 */
-	private _positionX?: Param;
 	get positionX(): Param {
 		if (!this._positionX) {
 			this._positionX = new Param({
@@ -136,6 +148,27 @@ export class ListenerInstance extends ToneAudioNode<ListenerOptions> {
 			});
 		}
 		return this._upZ;
+	}
+
+	/**
+	 * get()/set() (inherited from ToneWithContext) duck-type each property
+	 * via `this[attribute]`, which would force the lazy getters above to
+	 * construct on a context with no native position/forward/up AudioParams.
+	 * Skip them there: get() falls back to the static defaults and set() is
+	 * a no-op, since there is no underlying AudioParam to read or write.
+	 */
+	get(): ListenerOptions {
+		if (!this._hasPositionParams) {
+			return ListenerInstance.getDefaults();
+		}
+		return super.get();
+	}
+
+	set(props: RecursivePartial<ListenerOptions>): this {
+		if (!this._hasPositionParams) {
+			return this;
+		}
+		return super.set(props);
 	}
 
 	static getDefaults(): ListenerOptions {


### PR DESCRIPTION
Fixes #1457

`Listener` eagerly wraps all nine `context.rawContext.listener.{positionX..upZ}` AudioParams as `Param` instances in the constructor. Firefox implements none of these `AudioListener` AudioParams (confirmed via MDN browser-compat-data and directly on Firefox 150.0.2: `'positionX' in AudioListener.prototype === false`), so `context.rawContext.listener.positionX` (etc.) is `undefined` there. `Param`'s constructor asserts the incoming value is an `AudioParam` and throws `"param must be an AudioParam"` otherwise, so on Firefox:

```js
Tone.setContext(new AudioContext());
Tone.getDestination(); // -> "param must be an AudioParam"
```

throws immediately at context initialization, before any 3D spatialization (`Listener`/`Panner3D`) is ever used. standardized-audio-context polyfills these params for Tone's default context, which is why this only surfaces when a consumer passes their own native `AudioContext` -- the documented recipe for AudioWorklet interop (e.g. hosting a WAM 2.0 plugin).

**Fix**

- The nine `Param` fields are now getters that lazily construct their `Param` on first access instead of eagerly in the constructor, per the approach discussed in the issue. `dispose()` only disposes params that were actually constructed, so it no longer forces construction (and a Firefox throw) on a context that never used them.
- `get()`/`set()` (inherited from `ToneWithContext`) duck-type each attribute via `this[attribute]`, which would still force the lazy getters to construct -- and throw -- even when called generically rather than via direct property access. `ListenerInstance` now feature-detects once, in the constructor, whether the native `AudioListener` implements these AudioParams (`isAudioParam(this.context.rawContext.listener.positionX)`), and overrides `get()`/`set()` to fall back to `ListenerInstance.getDefaults()` / no-op when they don't. No browser-sniffing, no `isFirefox`-style branching -- just feature detection against the same `rawContext.listener` object the lazy getters already read.

**Testing**

Added two regression tests to `Listener.test.ts` that construct a `ListenerInstance` on a mock context whose raw `AudioListener` has none of the nine AudioParams (mirroring Firefox): one asserts construction no longer throws, the other asserts `.get()` and `.set({ positionX: 1 })` no longer throw either. Confirmed both are non-vacuous by reverting only `Listener.ts` to its pre-fix state (keeping the new tests) and rerunning -- the suite fails with the exact reported error, `AssertionError: expected [Function] to not throw an error but Error: param must be an AudioParam was thrown`, once at construction and once inside `.get()`.

Full re-verification from the final state (clean working tree):
- `npx tsc --noEmit` -- clean, no errors.
- `npx tsc` (full build) -- clean.
- `npx web-test-runner --config=./test/web-test-runner.config.js --group core` -- `Chromium: 38/38 test files | 839 passed, 0 failed, 2 skipped` (the 2 skips are pre-existing and unrelated to this change).
- `npx eslint Tone/core/context/Listener.ts Tone/core/context/Listener.test.ts` -- exit 0, no output.
- `npx prettier --check` on both touched files -- `All matched files use Prettier code style!`

Did not run the other test groups (`component`/`effect`/`event`/`instrument`/`signal`/`source`) or the integration/example scripts (`test:integrations`, `test:examples`) -- only `Tone/core/context/Listener.ts` and its test file are touched, so `core` is the only group with signal on this change.
