### PR TITLE
fix: Clock.start() flushes pending events/ticks before advancing a stale _lastUpdate

### DIFF
--- a/Tone/core/clock/Clock.test.ts
+++ b/Tone/core/clock/Clock.test.ts
@@ -354,6 +354,67 @@ describe("Clock", () => {
 				clock.start(0, 4);
 			});
 		});
+
+		it("does not replay stale pre-restart ticks when the loop update has fallen behind a restart (#1419)", () => {
+			const observedTicks: Array<number | undefined> = [];
+			return Offline(() => {
+				const clock = new Clock((time, ticks) => {
+					observedTicks.push(ticks);
+				}, 200);
+				const boundLoop = (
+					clock as unknown as { _boundLoop: () => void }
+				)._boundLoop;
+				clock.start(0);
+				// Detach the clock's own loop from the context's "tick" event
+				// so _lastUpdate genuinely never catches up, simulating the
+				// tick loop's cadence (default updateInterval=0.05s) falling
+				// behind a rapid stop/start cycle, as described in #1419.
+				clock.context.off("tick", boundLoop);
+				return atTime(0.02, (time) => {
+					clock.stop(time);
+					clock.start(time, 40);
+					// Reattach the loop: without a fix, it would replay ticks
+					// from [_lastUpdate, time) using the pre-restart TickSource
+					// state instead of the new offset.
+					clock.context.on("tick", boundLoop);
+				});
+			}, 0.03).then(() => {
+				expect(observedTicks).to.deep.equal([0, 1, 2, 3, 4, 40, 41]);
+			});
+		});
+
+		it("does not drop the pending stop event or pending ticks when stop and the following start happen at different times within the stale window (#1419)", () => {
+			const observedTicks: Array<number | undefined> = [];
+			const stopEvents: number[] = [];
+			return Offline(() => {
+				const clock = new Clock((time, ticks) => {
+					observedTicks.push(ticks);
+				}, 200);
+				const boundLoop = (
+					clock as unknown as { _boundLoop: () => void }
+				)._boundLoop;
+				clock.on("stop", (time) => {
+					stopEvents.push(time);
+				});
+				clock.start(0);
+				// Same staleness simulation as above, but this time stop() and
+				// the following start() are scheduled at two distinct times
+				// within the stale window, rather than the same instant.
+				clock.context.off("tick", boundLoop);
+				return atTime(0.025, () => {
+					clock.stop(0.015);
+					clock.start(0.02, 40);
+					clock.context.on("tick", boundLoop);
+				});
+			}, 0.03).then(() => {
+				// the "stop" event scheduled at 0.015 must still fire
+				expect(stopEvents).to.deep.equal([0.015]);
+				// ticks 0, 1, 2 (at 200Hz: 0, 0.005, 0.01) are still pending
+				// in [_lastUpdate, 0.015) and must still fire, followed by
+				// the post-restart ticks from offset 40
+				expect(observedTicks).to.deep.equal([0, 1, 2, 40, 41]);
+			});
+		});
 	});
 
 	context("Events", () => {

--- a/Tone/core/clock/Clock.ts
+++ b/Tone/core/clock/Clock.ts
@@ -133,6 +133,17 @@ export class Clock<TypeName extends "bpm" | "hertz" = "hertz">
 		const computedTime = this.toSeconds(time);
 		this.log("start", computedTime);
 		if (this._state.getValueAtTime(computedTime) !== "started") {
+			if (this._lastUpdate < computedTime && computedTime <= this.now()) {
+				// _lastUpdate has not yet caught up to this restart (e.g.
+				// rapid stop/start cycles outrunning the tick loop's
+				// cadence). Flush the state-transition events (e.g. a
+				// pending "stop") and tick callbacks still waiting in
+				// [_lastUpdate, computedTime) using the pre-restart
+				// TickSource state before it's reset below, so they aren't
+				// silently dropped, and so the next _loop() pass doesn't
+				// replay them using the post-restart state.
+				this._processRange(this._lastUpdate, computedTime);
+			}
 			this._state.setStateAtTime("started", computedTime);
 			this._tickSource.start(computedTime, offset);
 			if (computedTime < this._lastUpdate) {
@@ -267,9 +278,19 @@ export class Clock<TypeName extends "bpm" | "hertz" = "hertz">
 	private _loop(): void {
 		const startTime = this._lastUpdate;
 		const endTime = this.now();
-		this._lastUpdate = endTime;
 		this.log("loop", startTime, endTime);
+		this._processRange(startTime, endTime);
+	}
 
+	/**
+	 * Invoke the state-transition events (start/stop/pause) and tick
+	 * callbacks scheduled between startTime and endTime, and advance
+	 * _lastUpdate to endTime.
+	 * @param startTime The beginning of the range to process.
+	 * @param endTime The end of the range to process.
+	 */
+	private _processRange(startTime: number, endTime: number): void {
+		this._lastUpdate = endTime;
 		if (startTime !== endTime) {
 			// the state change events
 			this._state.forEachBetween(startTime, endTime, (e) => {

--- a/Tone/core/clock/Transport.test.ts
+++ b/Tone/core/clock/Transport.test.ts
@@ -1001,6 +1001,38 @@ describe("Transport", () => {
 			expect(invocations).to.equal(3);
 		});
 
+		it("does not drop the transport's stop event when stop/start outrun the clock's tick loop (#1419)", async () => {
+			const stopEvents: number[] = [];
+			await Offline((context) => {
+				const transport = new TransportInstance({ context });
+				transport.on("stop", (time) => {
+					stopEvents.push(time);
+				});
+				const clock = (
+					transport as unknown as {
+						_clock: {
+							context: typeof context;
+							_boundLoop: () => void;
+						};
+					}
+				)._clock;
+				transport.start(0);
+				// Detach the clock's own loop from the context's "tick"
+				// event so its _lastUpdate genuinely falls behind,
+				// simulating the tick loop's cadence (default
+				// updateInterval=0.05s) outrunning a rapid
+				// Transport.stop()/Transport.start() cycle, as described
+				// in #1419.
+				clock.context.off("tick", clock._boundLoop);
+				return atTime(0.02, () => {
+					transport.stop(0.015);
+					transport.start(0.018);
+					clock.context.on("tick", clock._boundLoop);
+				});
+			}, 0.03);
+			expect(stopEvents).to.deep.equal([0.015]);
+		});
+
 		it("invokes start event with correct offset", async () => {
 			let wasCalled = false;
 			await Offline((context) => {


### PR DESCRIPTION
### The bug

`Clock._loop()` processes state-transition events (start/stop/pause) and tick callbacks in the range `[_lastUpdate, now())`, and only advances `_lastUpdate` inside that same call. When rapid stop/start cycles outrun the cadence of the periodic tick loop (e.g. the context's `updateInterval`-driven tick, or several state changes squeezed into one processing window), `_lastUpdate` can be left stale — pointing to a time before a live restart — while `Clock.start()` has already reset the underlying `TickSource` to the new start time and offset. The next `_loop()` pass then reprocesses the stale range `[_lastUpdate, computedTime)` using the post-restart `TickSource` state, firing duplicate/stale callback ticks for history that was already correctly processed before the restart. This is the mechanism described in #1419.

An earlier version of this fix jumped `_lastUpdate` straight to the restart time whenever it was stale, which over-corrected: it silently discarded any state-transition event still pending in that window (most notably a `"stop"` that hadn't fired yet) and any tick callback still genuinely due in `[_lastUpdate, computedTime)`, whenever `stop()` and the following `start()` land at two different timestamps rather than the same instant. Since `Transport.stop()`/`Transport.start()` call `Clock.stop()`/`Clock.start()` directly and forward Clock's `"stop"` event as Transport's own public `"stop"` event, that meant an ordinary `Transport.stop(); Transport.start();` sequence could silently swallow the Transport `"stop"` event.

### The fix

`Clock.start()` now flushes the pending `[_lastUpdate, computedTime)` range using the pre-restart `TickSource` state *before* mutating it for the new start, whenever `_lastUpdate < computedTime <= this.now()`. Pending `"stop"`/`"pause"` events and ticks fire exactly once, and the next `_loop()` pass no longer replays them against the post-restart state. `_loop()`'s event/tick processing was extracted into a shared private `_processRange(startTime, endTime)` so both call sites (the periodic loop and the new flush-on-restart path) share the same logic.

I was not able to reproduce the full Transport loop-wrap / duplicate `Transport.schedule()` symptom from the reproduction linked on #1419 in the offline test harness, so this should be read as fixing the stale-`_lastUpdate` root cause it describes, not as a confirmed fix for that exact end-to-end reproduction. Refs #1419.

### Tests

- `Clock.test.ts`: a regression test that detaches the Clock's own loop from the context's `"tick"` event across a `stop()`/`start()` restart (simulating the tick loop's cadence falling behind), and asserts the callback reports only the post-restart ticks, not a replay of the pre-restart ones.
- `Clock.test.ts`: a second test covering `stop()` and the following `start()` at two distinct timestamps within the same stale window, asserting both the pending `"stop"` event and the ticks genuinely due before it still fire exactly once.
- `Transport.test.ts`: a Transport-level test reproducing `Transport.stop(); Transport.start();` under the same staleness and asserting Transport's public `"stop"` event is no longer dropped.

All three fail against the unfixed `Clock.ts` and pass with this change.

### Verification

`npx tsc`, `npx tsc --noEmit`, `npx eslint ./Tone`, and `npx prettier --check` on the three changed files are all clean.

`npx web-test-runner --config=./test/web-test-runner.config.js --group core`: 840 passed, 0 failed, 2 skipped (838 on `dev` plus the 2 net new `Clock.test.ts`/`Transport.test.ts` assertions).

`--group event` (Transport-dependent scheduling, as a broader sanity check beyond the narrowest scope): 180 passed, 0 failed, matching `dev`.

Full unfiltered suite (all groups, 145 files): 3072 passed, 5 failed, 43 skipped. The 5 failures are in `Tone/source/oscillator/*.test.ts` (waveform/phase golden-file comparisons) and are pre-existing on `dev` — confirmed via a stash-and-rerun before making any change here — unrelated to `Clock`/`Transport`. The other web-test-runner groups (`component`, `effect`, `instrument`, `signal`, `source`) and the puppeteer-based `test:integrations`/`test:html`/`test:examples` scripts were not run beyond that full pass, since `core` and `event` already exercise `Clock`/`TickSource`/`Transport`/scheduling directly.
